### PR TITLE
Fixing path to the documentations

### DIFF
--- a/dev_docker-compose.yml
+++ b/dev_docker-compose.yml
@@ -84,13 +84,13 @@ services:
 
   docs:
     build:
-      context: ./istsos4_docs/mkdocs
+      context: ./docs/mkdocs
       dockerfile: dockerfile
     #restart: always
     ports:
       - 8019:8000
     volumes:
-      - ./istsos4_docs/mkdocs:/docs
+      - ./docs/mkdocs:/docs
 
 volumes:
   v-istsos4-database-data:

--- a/edu_docker-compose.yml
+++ b/edu_docker-compose.yml
@@ -84,18 +84,18 @@ services:
 
   docs:
     build:
-      context: ./istsos4_docs/mkdocs
+      context: ./docs/mkdocs
       dockerfile: dockerfile
     #restart: always
     ports:
       - 8019:8000
     volumes:
-      - ./istsos4_docs/mkdocs:/docs
+      - ./docs/mkdocs:/docs
 
   tutorials:
     # image: quay.io/jupyter/scipy-notebook
     build:
-      context: ./istsos4_docs/tutorials
+      context: ./docs/tutorials
       dockerfile: dockerfile
     ports:
       - "10000:8888"


### PR DESCRIPTION
In both `dev_docker-compose.yml` and `edu_docker-compose.yml`, the path to the documentation was incorrect, making the project impossible to run with Docker. 