### PR TITLE
security fix: prevent SQL injection in user management DDL

### DIFF
--- a/api/app/utils/utils.py
+++ b/api/app/utils/utils.py
@@ -336,3 +336,32 @@ def build_expand(expand_node):
         parts.append(segment)
 
     return ",".join(parts)
+
+
+import re
+
+_USERNAME_RE = re.compile(r'^[a-zA-Z0-9_]{3,63}$')
+
+
+def validate_username(username: str) -> bool:
+    """Return True if *username* contains only letters, digits and underscores
+    and is between 3 and 63 characters long."""
+    return bool(_USERNAME_RE.match(username))
+
+
+def pg_quote_ident(name: str) -> str:
+    """Safely double-quote a PostgreSQL identifier (role name, username, etc.).
+
+    Doubles any embedded double-quote characters and wraps the result in
+    double quotes, matching the behaviour of PostgreSQL's quote_ident().
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+def pg_quote_literal(val: str) -> str:
+    """Safely single-quote a PostgreSQL string literal.
+
+    Doubles any embedded single-quote characters and wraps the result in
+    single quotes, matching the behaviour of PostgreSQL's quote_literal().
+    """
+    return "'" + val.replace("'", "''") + "'"

--- a/api/app/v1/endpoints/create/user.py
+++ b/api/app/v1/endpoints/create/user.py
@@ -15,6 +15,7 @@
 import json
 
 from app import HOSTNAME, POSTGRES_PORT_WRITE, SUBPATH, VERSION
+from app.utils.utils import pg_quote_ident, pg_quote_literal, validate_username
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
 from app.v1.endpoints.functions import insert_commit, set_role
@@ -79,6 +80,16 @@ async def create_user(
                         },
                     )
 
+                if not validate_username(payload["username"]):
+                    return JSONResponse(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        content={
+                            "code": 400,
+                            "type": "error",
+                            "message": "Invalid username: only letters, digits and underscores allowed (3\u201363 characters).",
+                        },
+                    )
+
                 if current_user is not None:
                     if current_user["role"] != "administrator":
                         raise InsufficientPrivilegeError
@@ -127,26 +138,18 @@ async def create_user(
                 if payload["role"] in ROLES:
                     payload["role"] = ROLES[payload["role"]]
 
-                query = """
-                    CREATE USER "{username}"
-                    WITH ENCRYPTED PASSWORD '{password}'
-                    IN ROLE "{role}";
-                """
                 await connection.execute(
-                    query.format(
-                        username=user["username"],
-                        password=password,
-                        role=payload["role"],
+                    "CREATE USER {} WITH ENCRYPTED PASSWORD {} IN ROLE {};".format(
+                        pg_quote_ident(user["username"]),
+                        pg_quote_literal(password),
+                        pg_quote_ident(payload["role"]),
                     )
                 )
 
-                query = """
-                    GRANT "{user}" TO "{role}";
-                """
                 await connection.execute(
-                    query.format(
-                        user=payload["username"],
-                        role=current_user["username"],
+                    "GRANT {} TO {};".format(
+                        pg_quote_ident(payload["username"]),
+                        pg_quote_ident(current_user["username"]),
                     )
                 )
 

--- a/api/app/v1/endpoints/delete/user.py
+++ b/api/app/v1/endpoints/delete/user.py
@@ -14,6 +14,7 @@
 
 from app import POSTGRES_PORT_WRITE
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.utils.utils import pg_quote_ident, validate_username
 from app.oauth import get_current_user
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import (
@@ -44,6 +45,16 @@ async def delete_user(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
+        if not validate_username(user):
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={
+                    "code": 400,
+                    "type": "error",
+                    "message": "Invalid username: only letters, digits and underscores allowed (3\u201363 characters).",
+                },
+            )
+
         async with pool.acquire() as connection:
             async with connection.transaction():
                 if current_user is not None:
@@ -63,10 +74,7 @@ async def delete_user(
                 """
                 await connection.execute(query, user)
 
-                query = """
-                    DROP ROLE {role};
-                """
-                await connection.execute(query.format(role=user))
+                await connection.execute(f"DROP ROLE {pg_quote_ident(user)};")
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")


### PR DESCRIPTION

## PR description
`POST /Users` and `DELETE /Users` were building `CREATE USER`, `GRANT`, and
`DROP ROLE` statements using `str.format()` with user-supplied values pasted
directly into the query string. A crafted username like:

    kinshuk"; CREATE ROLE hacker WITH SUPERUSER LOGIN PASSWORD 'pwned'; --

gets embedded as is and the injected statement executes.

what has been done in this PR:
- adds `pg_quote_ident()` and `pg_quote_literal()` to `utils.py` to safely
  quote identifiers and literals (mirrors PostgreSQL's own `quote_ident` /
  `quote_literal`)
- replaces all `str.format()` DDL calls in `create/user.py` and `delete/user.py`
  with the new helpers
- adds a `validate_username()` check at the entry point of both endpoints as
  defence in depth

it fixes: SQL injection in `create/user.py` (lines 129–150) and `delete/user.py` (line 69)


fixes #43 