### PR TITLE
Added .env.example and update README for setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,138 @@
+# Copy this file to .env and fill in your values before starting the stack.
+#   cp .env.example .env
+#
+# Variables marked REQUIRED have no default and the application will not work
+# correctly without them.
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+# Public hostname of the server (should match EXTERNAL_PORT).
+HOSTNAME=http://localhost:8018
+
+# Port Docker exposes the API on.
+EXTERNAL_PORT=8018
+
+# URL subpath for the API.
+SUBPATH=/istsos4
+
+# SensorThings API version segment.
+VERSION=/v1.1
+
+# Set to 1 to enable verbose debug output.
+DEBUG=0
+
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+
+POSTGRES_DB=istsos
+POSTGRES_USER=postgres
+
+# REQUIRED — choose a strong password.
+POSTGRES_PASSWORD=change_me
+
+POSTGRES_HOST=database
+POSTGRES_PORT=5432
+
+# External port Docker exposes Postgres on (useful for local psql access).
+POSTGRES_EXTERNAL_PORT=45432
+
+# Set to a write-replica host:port to split reads/writes. Leave empty for
+# single-node setups.
+POSTGRES_PORT_WRITE=
+
+# ---------------------------------------------------------------------------
+# istSOS administrator account
+# ---------------------------------------------------------------------------
+
+ISTSOS_ADMIN=admin
+
+# REQUIRED — choose a strong password.
+ISTSOS_ADMIN_PASSWORD=change_me
+
+# ---------------------------------------------------------------------------
+# Connection pool
+# ---------------------------------------------------------------------------
+
+PG_MAX_OVERFLOW=0
+PG_POOL_SIZE=10
+PG_POOL_TIMEOUT=30
+
+# ---------------------------------------------------------------------------
+# Query behaviour
+# ---------------------------------------------------------------------------
+
+# FULL | LIMIT_ESTIMATE | ESTIMATE_LIMIT
+# FULL always accurate; ESTIMATE_LIMIT fastest for large datasets.
+COUNT_MODE=FULL
+
+COUNT_ESTIMATE_THRESHOLD=10000
+TOP_VALUE=100
+PARTITION_CHUNK=10000
+
+# ---------------------------------------------------------------------------
+# Features
+# ---------------------------------------------------------------------------
+
+# Enable Redis-based token blacklisting (0 = disabled, 1 = enabled).
+REDIS=0
+
+# Allow duplicate observations (0 = disabled, 1 = enabled).
+DUPLICATES=0
+
+# Default coordinate reference system (EPSG code).
+EPSG=4326
+
+# Enable row-level authorization (0 = disabled, 1 = enabled).
+AUTHORIZATION=0
+
+# Allow unauthenticated read access (0 = disabled, 1 = enabled).
+ANONYMOUS_VIEWER=0
+
+# Enable network entity support (0 = disabled, 1 = enabled).
+NETWORK=0
+
+# Enable data versioning (0 = disabled, 1 = enabled).
+VERSIONING=0
+
+# Observed-area aggregation function: CONVEX_HULL | EXTENT
+ST_AGGREGATE=CONVEX_HULL
+
+# ---------------------------------------------------------------------------
+# Authentication  (REQUIRED when AUTHORIZATION=1)
+# ---------------------------------------------------------------------------
+
+# REQUIRED — generate with: openssl rand -hex 32
+SECRET_KEY=replace_with_output_of__openssl_rand_-hex_32
+
+ALGORITHM=HS256
+
+# Access token lifetime in minutes.
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+
+# ---------------------------------------------------------------------------
+# Dummy data generator (dev_docker-compose.yml only)
+# ---------------------------------------------------------------------------
+
+# Load synthetic data on first startup (0 = disabled, 1 = enabled).
+DUMMY_DATA=1
+
+# Wipe existing data before loading (0 = disabled, 1 = enabled).
+CLEAR_DATA=0
+
+N_THINGS=5
+N_OBSERVED_PROPERTIES=4
+
+# ISO 8601 duration: total time span of generated observations.
+INTERVAL=P7D
+
+# ISO 8601 duration: gap between observations.
+FREQUENCY=PT5M
+
+# ISO 8601 datetime: start of the generated observation series.
+START_DATETIME=2020-01-01T12:00:00.000+01:00
+
+# ISO 8601 duration: time-series partition size.
+CHUNK_INTERVAL=P7D

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 git clone https://github.com/istSOS/istSOS4.git
 ```
 
+## Environment setup
+
+Before starting any environment, copy the example env file and fill in your values:
+
+```sh
+cp .env.example .env
+```
+
+At minimum set `SECRET_KEY` (required for authentication) and the Postgres/admin
+passwords before running the stack.  All other variables default to sensible
+development values.
+
 ## Start DEV environment
 
 To start the Docker services, run:


### PR DESCRIPTION
The .env file is gitignored as it should be, but there's no .env.example in the repo. Anyone who clones the project has nothing to go on.

Most variables have defaults and the app will start, but SECRET_KEY has no
default at all   this means the auth breaks silently 

adds .env.example replicating  the existing .env structure with all variables and comments. 

sensitive values like the SECRET_KEY and the passwords are replaced with understandable placeholders. 
the setup step have been added to the README file as well for reference

fixes #45 