### PR TITLE
fix(update): parameterize SQL query in handle_nested_entities() to prevent SQL Injection

### DIFF
--- a/api/app/v1/endpoints/update/functions.py
+++ b/api/app/v1/endpoints/update/functions.py
@@ -395,7 +395,6 @@ async def update_network_entity(connection, network_id, payload):
     if payload:
         await update_entity(connection, "Network", network_id, payload)
 
-
 async def handle_nested_entities(
     connection, payload, entity_id, key, field, update_table
 ):
@@ -411,7 +410,17 @@ async def handle_nested_entities(
                         f"Invalid format: Each item in '{key}' should be a dictionary with a single key '@iot.id'."
                     )
                 related_id = item["@iot.id"]
+
+                # Check the type here first and return a Bad Request here
+                if not isinstance(related_id, int) or isinstance(related_id, bool):
+                    raise Exception(
+                        f"'@iot.id' must be an integer, got {type(related_id).__name__}"
+                    )
+                
+                # Parameterized Query
                 await connection.execute(
-                    f'UPDATE sensorthings."{update_table}" SET {field} = {entity_id} WHERE id = {related_id};'
+                    f'UPDATE sensorthings."{update_table}" SET "{field}" = $1 WHERE id = $2;',
+                    entity_id,
+                    related_id,
                 )
             payload.pop(key)


### PR DESCRIPTION
## Related Issue
Closes #51

## Problem
`handle_nested_entities()` in `app/v1/endpoints/update/functions.py` 
directly interpolates the user-supplied `@iot.id` value into 
an SQL f-string with no type validation, allowing arbitrary 
SQL execution across all 6 PATCH endpoints that call this function.

## Fix
two changes in `handle_nested_entities()`:

1. type check — rejects anything that isn't a plain integer 
before it touches the query
2. parameterized query — value is passed as `$1`, `$2` and 
never interpreted as SQL regardless of what's inside it
```python
related_id = item["@iot.id"]

if not isinstance(related_id, int) or isinstance(related_id, bool):
    raise Exception(
        f"'@iot.id' must be an integer, got {type(related_id).__name__}"
    )

await connection.execute(
    f'UPDATE sensorthings."{update_table}" SET "{field}" = $1 WHERE id = $2;',
    entity_id,
    related_id,
)
```