### PR TITLE
fix(create): add required field validation to prevent internal schema leakage

### DIFF
--- a/api/app/utils/utils.py
+++ b/api/app/utils/utils.py
@@ -207,6 +207,12 @@ def validate_payload_keys(payload, keys):
         raise Exception(f"Invalid keys in payload: {', '.join(invalid_keys)}")
 
 
+def validate_required_keys(payload, required_keys):
+    missing = [key for key in required_keys if key not in payload]
+    if missing:
+        raise Exception(f"Missing required fields: {', '.join(missing)}")
+
+
 def validate_epsg(key):
     crs = key.get("crs")
     if crs is not None:

--- a/api/app/v1/endpoints/create/feature_of_interest.py
+++ b/api/app/v1/endpoints/create/feature_of_interest.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -51,6 +51,8 @@ ALLOWED_KEYS = [
     "Observations",
 ]
 
+REQUIRED_KEYS = ["name", "encodingType", "feature"]
+
 
 @v1.api_route(
     "/FeaturesOfInterest",
@@ -75,6 +77,7 @@ async def create_feature_of_interest(
             raise Exception("Only content-type application/json is supported.")
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():

--- a/api/app/v1/endpoints/create/location.py
+++ b/api/app/v1/endpoints/create/location.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -51,6 +51,8 @@ ALLOWED_KEYS = [
     "Things",
 ]
 
+REQUIRED_KEYS = ["name", "encodingType", "location"]
+
 
 @v1.api_route(
     "/Locations",
@@ -75,6 +77,7 @@ async def create_location(
             raise Exception("Only content-type application/json is supported.")
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():
@@ -146,6 +149,7 @@ async def create_location_for_thing(
         payload["Things"] = [{"@iot.id": thing_id}]
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():

--- a/api/app/v1/endpoints/create/network.py
+++ b/api/app/v1/endpoints/create/network.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -41,6 +41,8 @@ PAYLOAD_EXAMPLE = {
 
 ALLOWED_KEYS = ["name", "Datastreams"]
 
+REQUIRED_KEYS = ["name"]
+
 
 @v1.api_route(
     "/Networks",
@@ -65,6 +67,7 @@ async def create_network(
             raise Exception("Only content-type application/json is supported.")
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():

--- a/api/app/v1/endpoints/create/observed_property.py
+++ b/api/app/v1/endpoints/create/observed_property.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -49,6 +49,8 @@ ALLOWED_KEYS = [
     "Datastreams",
 ]
 
+REQUIRED_KEYS = ["name", "definition", "description"]
+
 
 @v1.api_route(
     "/ObservedProperties",
@@ -73,6 +75,7 @@ async def create_observed_property(
             raise Exception("Only content-type application/json is supported.")
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():

--- a/api/app/v1/endpoints/create/sensor.py
+++ b/api/app/v1/endpoints/create/sensor.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -51,6 +51,8 @@ ALLOWED_KEYS = [
     "Datastreams",
 ]
 
+REQUIRED_KEYS = ["name", "encodingType", "metadata"]
+
 
 @v1.api_route(
     "/Sensors",
@@ -75,6 +77,7 @@ async def create_sensor(
             raise Exception("Only content-type application/json is supported.")
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():

--- a/api/app/v1/endpoints/create/thing.py
+++ b/api/app/v1/endpoints/create/thing.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -49,6 +49,8 @@ ALLOWED_KEYS = [
     "Datastreams",
 ]
 
+REQUIRED_KEYS = ["name"]
+
 
 @v1.api_route(
     "/Things",
@@ -73,6 +75,7 @@ async def create_thing(
             raise Exception("Only content-type application/json is supported.")
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():
@@ -144,6 +147,7 @@ async def create_thing_for_location(
         payload["Locations"] = [{"@iot.id": location_id}]
 
         validate_payload_keys(payload, ALLOWED_KEYS)
+        validate_required_keys(payload, REQUIRED_KEYS)
 
         async with pool.acquire() as connection:
             async with connection.transaction():


### PR DESCRIPTION
## Related Issue
Closes #53 

## Problem
The POST creation routers in `app/v1/endpoints/create/` validate that no extra keys are present using `ALLOWED_KEYS`, but they perform no upfront validation for missing required fields. The API takes the payload from the request body and attempts an SQL INSERT directly. Because the database schema expects these fields, this lets any user trigger internal database exceptions that leak the internal Postgres schema and constraint names back to the client.

## Fix
two changes across [app/utils/utils.py](cci:7://file:///c:/Myfiles/OSGeo/istSOS4/api/app/utils/utils.py:0:0-0:0) and the 6 create endpoints (`Things`, `Sensors`, `Locations`, `ObservedProperties`, `FeaturesOfInterest`, and `Networks`):

1. validation helper — added a new [validate_required_keys()](cci:1://file:///c:/Myfiles/OSGeo/istSOS4/api/app/utils/utils.py:209:0-212:73) function in [utils.py](cci:7://file:///c:/Myfiles/OSGeo/istSOS4/api/app/utils/utils.py:0:0-0:0). It explicitly checks the incoming JSON payload against a list of required keys, rejecting the request with a clean, unhandled-exception-free 400 Bad Request if any are missing.
2. early execution — `REQUIRED_KEYS` constants are now defined in every router file and checked immediately after the existing `ALLOWED_KEYS` validation, ensuring that malformed payloads are rejected *before* any database connection is acquired or query is constructed.

```python
# app/utils/utils.py
def validate_required_keys(payload, required_keys):
    missing = [key for key in required_keys if key not in payload]
    if missing:
        raise Exception(f"Missing required fields: {', '.join(missing)}")

# e.g., in app/v1/endpoints/create/sensor.py
REQUIRED_KEYS = ["name", "encodingType", "metadata"]

# Inside the route handler:
validate_payload_keys(payload, ALLOWED_KEYS)
validate_required_keys(payload, REQUIRED_KEYS)

async with pool.acquire() as connection:
    # ... Database operations ...
