### PR TITLE
Fix async Redis call not awaited in token revocation check

### DIFF
--- a/api/app/oauth.py
+++ b/api/app/oauth.py
@@ -105,7 +105,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme)):
     )
 
     try:
-        if redis.get(token) is not None:
+        if await redis.get(token) is not None:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Token has been revoked",


### PR DESCRIPTION
This PR fixes an async bug in `oauth.py` where the Redis token revocation check was not awaited.

The Redis client is asynchronous, so `redis.get(token)` should be awaited.

This change ensures the revocation check executes properly before validating the JWT.

Closes #55 