### PR TITLE
Fix refresh token generation to use separate expiration logic

### DIFF
--- a/api/app/oauth.py
+++ b/api/app/oauth.py
@@ -14,6 +14,8 @@
 
 from datetime import datetime, timedelta, timezone
 
+REFRESH_TOKEN_EXPIRE_DAYS = 7
+
 import asyncpg
 import jwt
 from app import (
@@ -88,10 +90,14 @@ def create_access_token(data: dict):
 
 
 def create_refresh_token(payload: dict):
-    return create_access_token(
-        data={"sub": payload.get("sub"), "role": payload.get("role")}
-    )
-
+    to_encode = {
+        "sub": payload.get("sub"),
+        "role": payload.get("role"),
+    }
+    expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt, int(expire.timestamp())
 
 def decode_token(token: str):
     return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])


### PR DESCRIPTION
This PR fixes the refresh token generation logic in `api/app/oauth.py`.

Currently, the `create_refresh_token` function simply calls `create_access_token`, which causes refresh tokens to be generated with the same expiration time and behavior as access tokens.

This prevents proper implementation of the refresh-token workflow.

### Current Implementation

```python
def create_refresh_token(payload: dict):
    return create_access_token(
        data={"sub": payload.get("sub"), "role": payload.get("role")}
    )

```

Since create_access_token uses ACCESS_TOKEN_EXPIRE_MINUTES, refresh tokens expire at the same time as access tokens.

Changes Introduced

This PR modifies create_refresh_token so that refresh tokens are generated independently with a longer expiration time.

Example implementation:
```python
REFRESH_TOKEN_EXPIRE_DAYS = 7

def create_refresh_token(payload: dict):
    to_encode = {
        "sub": payload.get("sub"),
        "role": payload.get("role"),
    }
    expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
    to_encode.update({"exp": expire})
    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
    return encoded_jwt, int(expire.timestamp())
```

### Benefits

Proper distinction between access tokens and refresh tokens
Enables correct token refresh workflows
Keeps the existing return format consistent with create_access_token
Improves authentication design without breaking existing interfaces

Related Issue
Fixes: #59 