### PR TITLE
Fix deprecation warnings

### DIFF
--- a/api/app/db/sqlalchemy_db.py
+++ b/api/app/db/sqlalchemy_db.py
@@ -23,7 +23,7 @@ from app import (
     POSTGRES_PORT,
 )
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 dsn = f"postgresql+asyncpg://{ISTSOS_ADMIN}:{ISTSOS_ADMIN_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+from contextlib import asynccontextmanager
 
 from app import HOSTNAME, POSTGRES_PORT_WRITE, SUBPATH, VERSION
 from app.db.asyncpg_db import get_pool, get_pool_w
@@ -32,9 +33,16 @@ async def initialize_pool():
             await asyncio.sleep(1)  # Use asyncio.sleep for asynchronous sleep
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await initialize_pool()
+    yield
+
+
 app = FastAPI(
     title="OGC SensorThings API",
     description="A SensorThings API implementation in Python using FastAPI.",
+    lifespan=lifespan,
     openapi_tags=[
         {
             "name": "Read root",
@@ -60,12 +68,6 @@ def __handle_root():
         "serverSettings": serverSettings,
     }
     return response
-
-
-@app.on_event("startup")
-async def startup_event():
-    await initialize_pool()  # Call the initialize_pool function at startup
-
 
 @app.get(f"{SUBPATH}{VERSION}", tags=["Read root"])
 async def read_root():

--- a/api/app/sta2rest/visitors.py
+++ b/api/app/sta2rest/visitors.py
@@ -828,7 +828,7 @@ class NodeVisitor(Visitor):
 
         main_query = main_query.limit(top_value).offset(skip_value)
         columns_to_select = []
-        for column in main_query.columns:
+        for column in main_query.selected_columns:
             if column.name not in labels:
                 columns_to_select.append(column)
             else:
@@ -850,7 +850,7 @@ class NodeVisitor(Visitor):
         if columns_to_select is not None:
             main_query = (
                 select(*columns_to_select)
-                .select_from(main_query)
+                .select_from(main_query.subquery())
                 .alias("main_query")
             )
         else:
@@ -913,9 +913,10 @@ class NodeVisitor(Visitor):
                 value = select_query[0].name
             else:
                 value = select_query[0].right
+            main_query_subquery = main_query.subquery()
             main_query = select(
-                main_query.c.json.op("->")(text(f"'{value}'"))
-            ).select_from(main_query)
+                main_query_subquery.c.json.op("->")(text(f"'{value}'"))
+            ).select_from(main_query_subquery)
 
         main_query_str = str(
             main_query.compile(


### PR DESCRIPTION
## summary
fixes by removing deprecated FastAPI and SQLAlchemy usage that caused warning noise and future-compatibility risk.

closes  #61


before the fix:
<img width="1206" height="346" alt="Image" src="https://github.com/user-attachments/assets/f45bd36c-51df-464d-b046-c7a8445404e3" />

after the fix:
<img width="1206" height="346" alt="image" src="https://github.com/user-attachments/assets/48aba4f3-c9f3-4ad7-8d50-21ee2da3c30d" />
