### PR TITLE
security fix:Tighten exception handling

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import asyncio
+import logging
 
+import asyncpg
 from app import HOSTNAME, POSTGRES_PORT_WRITE, SUBPATH, VERSION
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.settings import serverSettings, tables
@@ -21,15 +23,36 @@ from app.v1 import api
 from fastapi import FastAPI
 
 
+logger = logging.getLogger(__name__)
+
+
 async def initialize_pool():
+    retries = 0
+    max_retries = 30
+
     while True:
         try:
             await get_pool()  # Ensure get_pool() is awaited
             if POSTGRES_PORT_WRITE:
                 await get_pool_w()
             break
-        except Exception as e:
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ) as error:
+            retries += 1
+            logger.warning(
+                "Database pool initialization failed (attempt %s/%s): %s",
+                retries,
+                max_retries,
+                error,
+            )
+            if retries >= max_retries:
+                raise
             await asyncio.sleep(1)  # Use asyncio.sleep for asynchronous sleep
+        except ValueError:
+            logger.exception("Invalid database configuration during startup")
+            raise
 
 
 app = FastAPI(

--- a/api/app/v1/endpoints/create/user.py
+++ b/api/app/v1/endpoints/create/user.py
@@ -13,16 +13,24 @@
 # limitations under the License.
 
 import json
+import logging
 
 from app import HOSTNAME, POSTGRES_PORT_WRITE, SUBPATH, VERSION
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
 from app.v1.endpoints.functions import insert_commit, set_role
-from asyncpg.exceptions import InsufficientPrivilegeError, UniqueViolationError
+from asyncpg.exceptions import (
+    InsufficientPrivilegeError,
+    PostgresConnectionError,
+    QueryCanceledError,
+    TooManyConnectionsError,
+    UniqueViolationError,
+)
 from fastapi import APIRouter, Body, Depends, status
 from fastapi.responses import JSONResponse, Response
 
 v1 = APIRouter()
+logger = logging.getLogger(__name__)
 
 PAYLOAD_EXAMPLE = {
     "username": "cp1",
@@ -159,11 +167,24 @@ async def create_user(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={"message": "Insufficient privileges."},
         )
-    except Exception as e:
+    except (PostgresConnectionError, TooManyConnectionsError):
+        logger.exception("Database temporarily unavailable during user creation")
         return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={"message": str(e)},
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"message": "Database temporarily unavailable."},
+        )
+    except QueryCanceledError:
+        logger.exception("Database timeout during user creation")
+        return JSONResponse(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            content={"message": "Database request timed out."},
+        )
+    except Exception:
+        logger.exception("Unexpected error during user creation")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"message": "Internal server error."},
         )

--- a/api/app/v1/endpoints/read/read.py
+++ b/api/app/v1/endpoints/read/read.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import json
+import logging
 import traceback
 from datetime import datetime, timezone
 
+import asyncpg
 import ujson
 from app import (
     ANONYMOUS_VIEWER,
@@ -36,12 +38,13 @@ from app.settings import serverSettings, tables
 from app.sta2rest import sta2rest
 from app.utils.utils import build_nextLink
 from app.v1.endpoints.functions import set_role
-from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 
 v1 = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 user = Header(default=None, include_in_schema=False)
@@ -151,7 +154,7 @@ async def catch_all_get(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
@@ -160,12 +163,42 @@ async def catch_all_get(
                     "message": "Not Found",
                 },
             )
+        except Exception:
+            logger.exception("Unexpected streaming error in catch_all_get")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
+                },
+            )
 
-    except Exception as e:
+    except HTTPException:
+        raise
+    except (
+        asyncpg.PostgresConnectionError,
+        asyncpg.TooManyConnectionsError,
+    ):
+        logger.exception("Database unavailable in catch_all_get")
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={
+                "code": 503,
+                "type": "error",
+                "message": "Database temporarily unavailable",
+            },
+        )
+    except Exception:
+        logger.exception("Unexpected error in catch_all_get")
         traceback.print_exc()
         return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={"code": 400, "type": "error", "message": str(e)},
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={
+                "code": 500,
+                "type": "error",
+                "message": "Internal server error",
+            },
         )
 
 

--- a/api/tests/test_issue7_exception_handling.py
+++ b/api/tests/test_issue7_exception_handling.py
@@ -1,0 +1,116 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+API_DIR = str(Path(__file__).resolve().parents[1])
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+os.environ.setdefault("ISTSOS_ADMIN", "admin")
+os.environ.setdefault("ISTSOS_ADMIN_PASSWORD", "secret")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "istsos")
+os.environ.setdefault("POSTGRES_USER", "admin")
+os.environ.setdefault("SECRET_KEY", "test_secret_key_1234567890")
+os.environ.setdefault("ALGORITHM", "HS256")
+os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+
+from app import main as app_main
+from app.v1.endpoints.create import user as user_ep
+from app.v1.endpoints.read import read as read_ep
+
+
+class TestIssue7ExceptionHandling:
+    async def test_create_user_unexpected_error_returns_500_without_details(self):
+        pool = MagicMock()
+        tx = MagicMock()
+        tx.__aenter__ = AsyncMock(return_value=None)
+        tx.__aexit__ = AsyncMock(return_value=None)
+
+        conn = MagicMock()
+        conn.transaction = MagicMock(return_value=tx)
+        conn.fetchrow = AsyncMock(side_effect=RuntimeError("db boom details leaked"))
+
+        acq = MagicMock()
+        acq.__aenter__ = AsyncMock(return_value=conn)
+        acq.__aexit__ = AsyncMock(return_value=None)
+        pool.acquire = MagicMock(return_value=acq)
+
+        payload = {"username": "u1", "password": "p1", "role": "viewer"}
+
+        with patch.object(user_ep, "set_role", AsyncMock(return_value=None)):
+            response = await user_ep.create_user(
+                payload=payload,
+                current_user={"role": "administrator", "username": "admin"},
+                pgpool=pool,
+            )
+
+        assert response.status_code == 500
+        assert "details leaked" not in response.body.decode()
+
+    async def test_catch_all_get_stream_error_returns_500(self):
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/istsos4/v1.1/Things",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+        request = Request(scope)
+
+        async def broken_stream(*args, **kwargs):
+            if False:
+                yield None
+            raise RuntimeError("stream boom")
+
+        with patch.object(
+            read_ep.sta2rest.STA2REST,
+            "convert_query",
+            return_value={
+                "main_entity": "Thing",
+                "main_query": "SELECT 1",
+                "top_value": 1,
+                "is_count": False,
+                "count_queries": [],
+                "as_of_value": None,
+                "from_to_value": False,
+                "single_result": False,
+            },
+        ), patch.object(
+            read_ep,
+            "asyncpg_stream_results",
+            side_effect=lambda *a, **k: broken_stream(),
+        ):
+            response = await read_ep.catch_all_get(
+                request=request,
+                path_name="Things",
+                current_user=None,
+                pool=MagicMock(),
+                params=None,
+            )
+
+        assert response.status_code == 500
+        assert response.body.decode() == (
+            '{"code":500,"type":"error","message":"Internal server error"}'
+        )
+
+    async def test_initialize_pool_valueerror_is_not_retried(self):
+        with patch.object(
+            app_main,
+            "get_pool",
+            AsyncMock(side_effect=ValueError("invalid config")),
+        ) as get_pool_mock:
+            with pytest.raises(ValueError):
+                await app_main.initialize_pool()
+
+        assert get_pool_mock.await_count == 1


### PR DESCRIPTION
## Description
fixed issue by reducing broad exception masking in critical paths and returning safer, 
semantically correct server responses

closes #67 


### before 
- `create_user` returned 400 with leaked internal message.
- `catch_all_get` could return 404 for non not found runtime errors.
<img width="1242" height="295" alt="Image" src="https://github.com/user-attachments/assets/1b53ef98-9d03-4b15-ac55-3b9b0943cb46" />


### after the committed changes 

- `create_user` returns 500 with message.
- `catch_all_get` returns 500 for stream or runtime failures.
- Focused tests pass:
  - `python -m pytest -q tests/test_issue7_exception_handling.py` and the results for it is shown below


<img width="1242" height="295" alt="image" src="https://github.com/user-attachments/assets/2b0054b1-263e-450c-a814-5b14ee4f3b40" />
