### PR TITLE
test(utils): add tests for get_result_type_and_column

### DIFF
--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -36,7 +36,10 @@ from api.app.utils.utils import (
     get_result_type_and_column, 
     extract_iot_id)
 
-# Helper Function
+
+# Helper functions
+
+
 def assert_column_value(columns, values, column_name, expected_value):
     """Assert that a named column holds the expected value."""
     assert column_name in columns, (
@@ -48,7 +51,16 @@ def assert_column_value(columns, values, column_name, expected_value):
     )
 
 
+# safe_parse_datetime
+
+
 class TestDatetimeParsing:
+    """
+    Tests for safe_parse_datetime(), which wraps dateutil.parser.parse
+    and returns None instead of raising on invalid input.
+    Covers valid ISO strings and inputs that should silently return None.
+    """
+
     def test_safe_parse_datetime_valid(self):
         assert safe_parse_datetime("2024-02-01T12:00Z") is not None
 
@@ -57,26 +69,38 @@ class TestDatetimeParsing:
         assert safe_parse_datetime("N/A") is None
 
 
+# extract_iot_id
+
+
 class TestIotIdExtraction:
+    """
+    Tests for extract_iot_id(), which pulls the '@iot.id' integer from
+    an association dict. The function must raise ValueError for anything
+    that is not a dict, missing the key, or has a non-integer value.
+    """
+
     def test_extract_iot_id_valid(self):
         assert extract_iot_id({"@iot.id": 42}) == 42
 
     def test_extract_iot_id_invalid_structure(self):
-        try:
+        with pytest.raises(ValueError, match="dict"):
             extract_iot_id("not a dict")
-        except ValueError as e:
-            assert "dict" in str(e)
 
     def test_extract_iot_id_missing_key(self):
-        try:
+        with pytest.raises(ValueError, match="Missing '@iot.id'"):
             extract_iot_id({})
-        except ValueError as e:
-            assert "Missing '@iot.id'" in str(e)
+
+
+# get_result_type_and_column 
 
 
 class TestReturnStructure:
-    """The function must always return a 3-tuple of (int, list, list)
-    where values and columns have equal length and always contain 4 entries."""
+    """
+    Verifies the shape of the return value regardless of input type.
+    The function must always return a 3-tuple of (int, list, list)
+    where values and columns have equal length and always contain
+    exactly 4 entries, one per DB result column.
+    """
 
     def test_returns_a_three_element_tuple(self):
         result = get_result_type_and_column("hello")
@@ -98,6 +122,12 @@ class TestReturnStructure:
 
 
 class TestStringInput:
+    """
+    Verifies that a str value is classified as result_type = 3 and stored
+    in resultString. All other columns must be None. No content-based
+    inference should occur, a string that looks like a number or boolean
+    must still be treated as a string.
+    """
 
     def test_result_type_is_3(self):
         result_type, _, _ = get_result_type_and_column("hello")
@@ -134,6 +164,12 @@ class TestStringInput:
 
 
 class TestDictInput:
+    """
+    Verifies that a dict value is classified as result_type = 2 and stored
+    in resultJSON. All other columns must be None. The original dict
+    reference must be preserved, no copying should occur since the
+    DB layer expects to receive the exact object passed in.
+    """
 
     def test_result_type_is_2(self):
         result_type, _, _ = get_result_type_and_column({"temp": 22})
@@ -170,6 +206,13 @@ class TestDictInput:
 
 
 class TestBoolInput:
+    """
+    Verifies that a bool value is classified as result_type = 1 and stored
+    in resultBoolean. The string form must be lower-case ('true'/'false')
+    to match the SensorThings convention. Critically, since bool is a
+    subclass of int in Python, this branch must be checked before the
+    numeric branch to avoid misclassifying True/False as result_type = 0.
+    """
 
     def test_result_type_is_1_for_true(self):
         result_type, _, _ = get_result_type_and_column(True)
@@ -215,6 +258,12 @@ class TestBoolInput:
 
 
 class TestIntInput:
+    """
+    Verifies that an int value is classified as result_type = 0 and stored
+    in resultNumber. resultString receives the str() form for text-based
+    queries. Covers positive, negative, and zero, including the falsy
+    zero trap where a truthiness check would incorrectly skip the branch.
+    """
 
     def test_result_type_is_0_for_positive_int(self):
         result_type, _, _ = get_result_type_and_column(42)
@@ -245,6 +294,12 @@ class TestIntInput:
 
 
 class TestFloatInput:
+    """
+    Verifies that a float value is classified as result_type = 0 alongside
+    int, and stored in resultNumber. resultString receives str(value),
+    which preserves the decimal point (str(1.0) -> "1.0"). Covers
+    positive, negative, and zero floats.
+    """
 
     def test_result_type_is_0_for_float(self):
         result_type, _, _ = get_result_type_and_column(3.14)
@@ -276,6 +331,12 @@ class TestFloatInput:
 
 
 class TestInvalidInput:
+    """
+    Verifies that any unsupported type raises Exception with the message
+    'Cannot cast result to a valid type'. Covers None, list, tuple, set,
+    bytes, and a custom object, basically anything the function has no branch for
+    must fail loudly rather than silently returning wrong data.
+    """
 
     def test_none_raises(self):
         with pytest.raises(Exception, match="Cannot cast result to a valid type"):
@@ -306,8 +367,12 @@ class TestInvalidInput:
 
 
 class TestColumnOrdering:
-    """The first column must always be the active (non-None) one,
-    since callers zip values and columns and expect this contract."""
+    """
+    Verifies that the first column in the returned list is always the
+    active (non-None) one. Callers zip values and columns together and
+    rely on this ordering contract, if it breaks, the wrong column gets
+    written to in the DB.
+    """
 
     def test_first_column_is_result_string_for_string(self):
         _, _, columns = get_result_type_and_column("hello")
@@ -330,7 +395,7 @@ class TestColumnOrdering:
         assert columns[0] == "resultNumber"
 
     def test_first_value_is_never_none(self):
-        """value[0] must always be the actual payload, never None."""
+        """values[0] must always be the actual payload, never None."""
         cases = ["hello", {"k": "v"}, True, 42, 3.14]
         for val in cases:
             _, values, _ = get_result_type_and_column(val)

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -34,12 +34,10 @@ sys.path.insert(0, API_DIR)
 from api.app.utils.utils import (
     safe_parse_datetime,
     get_result_type_and_column, 
-    extract_iot_id)
-
+    extract_iot_id
+)
 
 # Helper functions
-
-
 def assert_column_value(columns, values, column_name, expected_value):
     """Assert that a named column holds the expected value."""
     assert column_name in columns, (
@@ -52,8 +50,6 @@ def assert_column_value(columns, values, column_name, expected_value):
 
 
 # safe_parse_datetime
-
-
 class TestDatetimeParsing:
     """
     Tests for safe_parse_datetime(), which wraps dateutil.parser.parse
@@ -70,8 +66,6 @@ class TestDatetimeParsing:
 
 
 # extract_iot_id
-
-
 class TestIotIdExtraction:
     """
     Tests for extract_iot_id(), which pulls the '@iot.id' integer from
@@ -92,8 +86,6 @@ class TestIotIdExtraction:
 
 
 # get_result_type_and_column 
-
-
 class TestReturnStructure:
     """
     Verifies the shape of the return value regardless of input type.

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -1,10 +1,24 @@
 """
-Testing the freshly created helper functions.
+Tests for helper functions in api/app/utils/utils.py
 
-Since the test directory is located in this way, I had to first find project root
-where api directory was and then insert it to path manually.
+The function maps an observation result value to:
+  - a result_type code (0–3)
+  - an ordered list of column names
+  - an ordered list of values to write into those columns
 
-Author : Vishmayraj
+Result type codes:
+    0 → numeric (int or float)
+    1 → boolean
+    2 → JSON / dict
+    3 → string
+
+Since the test directory is located outside the api package, the project root
+and api directory are inserted into sys.path manually.
+
+Usage:
+    pytest test/test_utils_helper.py -v
+
+Author: Vishmayraj
 """
 
 import sys
@@ -17,26 +31,44 @@ API_DIR = os.path.join(PROJECT_ROOT, 'api')
 sys.path.insert(0, PROJECT_ROOT)
 sys.path.insert(0, API_DIR)
 
-from api.app.utils.utils import safe_parse_datetime, extract_iot_id
+from api.app.utils.utils import (
+    safe_parse_datetime,
+    get_result_type_and_column, 
+    extract_iot_id)
 
-def test_safe_parse_datetime_valid():
-    assert safe_parse_datetime("2024-02-01T12:00Z") is not None
+class TestDatetimeParsing:
+    def test_safe_parse_datetime_valid(self):
+        assert safe_parse_datetime("2024-02-01T12:00Z") is not None
 
-def test_safe_parse_datetime_invalid():
-    assert safe_parse_datetime("0000-00-00") is None
-    assert safe_parse_datetime("N/A") is None
+    def test_safe_parse_datetime_invalid(self):
+        assert safe_parse_datetime("0000-00-00") is None
+        assert safe_parse_datetime("N/A") is None
 
-def test_extract_iot_id_valid():
-    assert extract_iot_id({"@iot.id": 42}) == 42
+class TestIotIdExtraction:
+    def test_extract_iot_id_valid(self):
+        assert extract_iot_id({"@iot.id": 42}) == 42
 
-def test_extract_iot_id_invalid_structure():
-    try:
-        extract_iot_id("not a dict")
-    except ValueError as e:
-        assert "dict" in str(e)
+    def test_extract_iot_id_invalid_structure(self):
+        try:
+            extract_iot_id("not a dict")
+        except ValueError as e:
+            assert "dict" in str(e)
 
-def test_extract_iot_id_missing_key():
-    try:
-        extract_iot_id({})
-    except ValueError as e:
-        assert "Missing '@iot.id'" in str(e)
+    def test_extract_iot_id_missing_key(self):
+        try:
+            extract_iot_id({})
+        except ValueError as e:
+            assert "Missing '@iot.id'" in str(e)
+
+
+# Helper Function
+def assert_column_value(columns, values, column_name, expected_value):
+    """Assert that a named column holds the expected value."""
+    assert column_name in columns, (
+        f"Expected column '{column_name}' to be present, got: {columns}"
+    )
+    idx = columns.index(column_name)
+    assert values[idx] == expected_value, (
+        f"Column '{column_name}': expected {expected_value!r}, got {values[idx]!r}"
+    )
+

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -96,9 +96,18 @@ class TestStringInput:
         assert_column_value(columns, values, "resultString", "")
 
     def test_numeric_looking_string_stays_string(self):
-        """ "42" is a str, therefore no content based type inference should occur."""
+        """ "42" is a str. Therefore no content-based type inference should occur."""
         result_type, _, _ = get_result_type_and_column("42")
         assert result_type == 3
+
+    def test_boolean_looking_string_stays_string(self):
+        result_type, _, _ = get_result_type_and_column("true")
+        assert result_type == 3
+
+    def test_unicode_string(self):
+        result_type, values, columns = get_result_type_and_column("温度")
+        assert result_type == 3
+        assert_column_value(columns, values, "resultString", "温度")
 
 
 class TestDictInput:
@@ -118,6 +127,16 @@ class TestDictInput:
         assert_column_value(columns, values, "resultNumber", None)
         assert_column_value(columns, values, "resultString", None)
 
+    def test_empty_dict(self):
+        result_type, values, columns = get_result_type_and_column({})
+        assert result_type == 2
+        assert_column_value(columns, values, "resultJSON", {})
+
+    def test_nested_dict(self):
+        payload = {"sensor": {"id": 1, "value": 99.5}}
+        result_type, values, columns = get_result_type_and_column(payload)
+        assert result_type == 2
+        assert_column_value(columns, values, "resultJSON", payload)
 
     def test_original_dict_reference_is_preserved(self):
         """No copy should be made, the DB layer receives the same object."""
@@ -157,6 +176,14 @@ class TestBoolInput:
         _, values, columns = get_result_type_and_column(False)
         assert_column_value(columns, values, "resultBoolean", False)
 
+    def test_result_string_is_lowercase_true(self):
+        """SensorThings expects "true", not Python's "True"."""
+        _, values, columns = get_result_type_and_column(True)
+        assert_column_value(columns, values, "resultString", "true")
+
+    def test_result_string_is_lowercase_false(self):
+        _, values, columns = get_result_type_and_column(False)
+        assert_column_value(columns, values, "resultString", "false")
 
     def test_other_columns_are_none(self):
         _, values, columns = get_result_type_and_column(True)
@@ -186,6 +213,12 @@ class TestIntInput:
         _, values, columns = get_result_type_and_column(42)
         assert_column_value(columns, values, "resultBoolean", None)
         assert_column_value(columns, values, "resultJSON", None)
+
+    def test_zero_is_numeric_not_falsy(self):
+        """0 is falsy in Python, ensure isinstance is used, not truthiness."""
+        result_type, values, columns = get_result_type_and_column(0)
+        assert result_type == 0
+        assert_column_value(columns, values, "resultNumber", 0)
 
 
 class TestFloatInput:

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -64,6 +64,9 @@ class TestDatetimeParsing:
         assert safe_parse_datetime("0000-00-00") is None
         assert safe_parse_datetime("N/A") is None
 
+    def test_safe_parse_datetime_none(self):
+        assert safe_parse_datetime(None) is None
+
 
 # extract_iot_id
 class TestIotIdExtraction:
@@ -83,6 +86,14 @@ class TestIotIdExtraction:
     def test_extract_iot_id_missing_key(self):
         with pytest.raises(ValueError, match="Missing '@iot.id'"):
             extract_iot_id({})
+
+    def test_extract_iot_id_non_integer(self):
+        with pytest.raises(ValueError, match="Expected int"):
+            extract_iot_id({"@iot.id": "42"})
+    
+    def test_extract_iot_id_none_value(self):
+        with pytest.raises(ValueError, match="Expected int"):
+            extract_iot_id({"@iot.id": None})
 
 
 # get_result_type_and_column 

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -36,6 +36,18 @@ from api.app.utils.utils import (
     get_result_type_and_column, 
     extract_iot_id)
 
+# Helper Function
+def assert_column_value(columns, values, column_name, expected_value):
+    """Assert that a named column holds the expected value."""
+    assert column_name in columns, (
+        f"Expected column '{column_name}' to be present, got: {columns}"
+    )
+    idx = columns.index(column_name)
+    assert values[idx] == expected_value, (
+        f"Column '{column_name}': expected {expected_value!r}, got {values[idx]!r}"
+    )
+
+
 class TestDatetimeParsing:
     def test_safe_parse_datetime_valid(self):
         assert safe_parse_datetime("2024-02-01T12:00Z") is not None
@@ -43,6 +55,7 @@ class TestDatetimeParsing:
     def test_safe_parse_datetime_invalid(self):
         assert safe_parse_datetime("0000-00-00") is None
         assert safe_parse_datetime("N/A") is None
+
 
 class TestIotIdExtraction:
     def test_extract_iot_id_valid(self):
@@ -61,14 +74,146 @@ class TestIotIdExtraction:
             assert "Missing '@iot.id'" in str(e)
 
 
-# Helper Function
-def assert_column_value(columns, values, column_name, expected_value):
-    """Assert that a named column holds the expected value."""
-    assert column_name in columns, (
-        f"Expected column '{column_name}' to be present, got: {columns}"
-    )
-    idx = columns.index(column_name)
-    assert values[idx] == expected_value, (
-        f"Column '{column_name}': expected {expected_value!r}, got {values[idx]!r}"
-    )
+class TestStringInput:
 
+    def test_result_type_is_3(self):
+        result_type, _, _ = get_result_type_and_column("hello")
+        assert result_type == 3
+
+    def test_result_string_holds_the_value(self):
+        _, values, columns = get_result_type_and_column("hello")
+        assert_column_value(columns, values, "resultString", "hello")
+
+    def test_other_columns_are_none(self):
+        _, values, columns = get_result_type_and_column("hello")
+        assert_column_value(columns, values, "resultBoolean", None)
+        assert_column_value(columns, values, "resultNumber", None)
+        assert_column_value(columns, values, "resultJSON", None)
+
+    def test_empty_string(self):
+        result_type, values, columns = get_result_type_and_column("")
+        assert result_type == 3
+        assert_column_value(columns, values, "resultString", "")
+
+    def test_numeric_looking_string_stays_string(self):
+        """ "42" is a str, therefore no content based type inference should occur."""
+        result_type, _, _ = get_result_type_and_column("42")
+        assert result_type == 3
+
+
+class TestDictInput:
+
+    def test_result_type_is_2(self):
+        result_type, _, _ = get_result_type_and_column({"temp": 22})
+        assert result_type == 2
+
+    def test_result_json_holds_the_dict(self):
+        payload = {"temp": 22, "unit": "C"}
+        _, values, columns = get_result_type_and_column(payload)
+        assert_column_value(columns, values, "resultJSON", payload)
+
+    def test_other_columns_are_none(self):
+        _, values, columns = get_result_type_and_column({"a": 1})
+        assert_column_value(columns, values, "resultBoolean", None)
+        assert_column_value(columns, values, "resultNumber", None)
+        assert_column_value(columns, values, "resultString", None)
+
+
+    def test_original_dict_reference_is_preserved(self):
+        """No copy should be made, the DB layer receives the same object."""
+        payload = {"k": "v"}
+        _, values, columns = get_result_type_and_column(payload)
+        idx = columns.index("resultJSON")
+        assert values[idx] is payload
+
+
+class TestBoolInput:
+
+    def test_result_type_is_1_for_true(self):
+        result_type, _, _ = get_result_type_and_column(True)
+        assert result_type == 1
+
+    def test_result_type_is_1_for_false(self):
+        result_type, _, _ = get_result_type_and_column(False)
+        assert result_type == 1
+
+    def test_true_is_not_classified_as_numeric(self):
+        """bool is a subclass of int. Thus, True must not become result_type=0."""
+        result_type, _, _ = get_result_type_and_column(True)
+        assert result_type != 0, (
+            "True was classified as numeric. "
+            "Check that the bool branch appears before int/float."
+        )
+
+    def test_false_is_not_classified_as_numeric(self):
+        result_type, _, _ = get_result_type_and_column(False)
+        assert result_type != 0
+
+    def test_result_boolean_holds_true(self):
+        _, values, columns = get_result_type_and_column(True)
+        assert_column_value(columns, values, "resultBoolean", True)
+
+    def test_result_boolean_holds_false(self):
+        _, values, columns = get_result_type_and_column(False)
+        assert_column_value(columns, values, "resultBoolean", False)
+
+
+    def test_other_columns_are_none(self):
+        _, values, columns = get_result_type_and_column(True)
+        assert_column_value(columns, values, "resultNumber", None)
+        assert_column_value(columns, values, "resultJSON", None)
+
+
+class TestIntInput:
+
+    def test_result_type_is_0_for_positive_int(self):
+        result_type, _, _ = get_result_type_and_column(42)
+        assert result_type == 0
+
+    def test_result_type_is_0_for_negative_int(self):
+        result_type, _, _ = get_result_type_and_column(-7)
+        assert result_type == 0
+
+    def test_result_number_holds_the_value(self):
+        _, values, columns = get_result_type_and_column(42)
+        assert_column_value(columns, values, "resultNumber", 42)
+
+    def test_result_string_holds_string_form(self):
+        _, values, columns = get_result_type_and_column(42)
+        assert_column_value(columns, values, "resultString", "42")
+
+    def test_other_columns_are_none(self):
+        _, values, columns = get_result_type_and_column(42)
+        assert_column_value(columns, values, "resultBoolean", None)
+        assert_column_value(columns, values, "resultJSON", None)
+
+
+class TestFloatInput:
+
+    def test_result_type_is_0_for_float(self):
+        result_type, _, _ = get_result_type_and_column(3.14)
+        assert result_type == 0
+
+    def test_result_number_holds_the_float(self):
+        _, values, columns = get_result_type_and_column(3.14)
+        assert_column_value(columns, values, "resultNumber", 3.14)
+
+    def test_result_string_holds_string_form_of_float(self):
+        """str(1.0) -> "1.0", preserving the decimal point."""
+        _, values, columns = get_result_type_and_column(1.0)
+        assert_column_value(columns, values, "resultString", "1.0")
+
+    def test_negative_float(self):
+        result_type, values, columns = get_result_type_and_column(-0.5)
+        assert result_type == 0
+        assert_column_value(columns, values, "resultNumber", -0.5)
+
+    def test_zero_float(self):
+        result_type, values, columns = get_result_type_and_column(0.0)
+        assert result_type == 0
+        assert_column_value(columns, values, "resultNumber", 0.0)
+
+    def test_other_columns_are_none(self):
+        _, values, columns = get_result_type_and_column(3.14)
+        assert_column_value(columns, values, "resultBoolean", None)
+        assert_column_value(columns, values, "resultJSON", None)

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -250,3 +250,34 @@ class TestFloatInput:
         _, values, columns = get_result_type_and_column(3.14)
         assert_column_value(columns, values, "resultBoolean", None)
         assert_column_value(columns, values, "resultJSON", None)
+
+
+class TestInvalidInput:
+
+    def test_none_raises(self):
+        with pytest.raises(Exception, match="Cannot cast result to a valid type"):
+            get_result_type_and_column(None)
+
+    def test_list_raises(self):
+        with pytest.raises(Exception, match="Cannot cast result to a valid type"):
+            get_result_type_and_column([1, 2, 3])
+
+    def test_tuple_raises(self):
+        with pytest.raises(Exception, match="Cannot cast result to a valid type"):
+            get_result_type_and_column((1, 2))
+
+    def test_set_raises(self):
+        with pytest.raises(Exception, match="Cannot cast result to a valid type"):
+            get_result_type_and_column({1, 2, 3})
+
+    def test_bytes_raises(self):
+        with pytest.raises(Exception, match="Cannot cast result to a valid type"):
+            get_result_type_and_column(b"bytes")
+
+    def test_custom_object_raises(self):
+        class Foo:
+            """Dummy class representing an unsupported result type."""
+            pass
+        with pytest.raises(Exception, match="Cannot cast result to a valid type"):
+            get_result_type_and_column(Foo())
+

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -74,6 +74,29 @@ class TestIotIdExtraction:
             assert "Missing '@iot.id'" in str(e)
 
 
+class TestReturnStructure:
+    """The function must always return a 3-tuple of (int, list, list)
+    where values and columns have equal length and always contain 4 entries."""
+
+    def test_returns_a_three_element_tuple(self):
+        result = get_result_type_and_column("hello")
+        assert isinstance(result, tuple) and len(result) == 3
+
+    def test_first_element_is_an_integer(self):
+        result_type, _, _ = get_result_type_and_column("hello")
+        assert isinstance(result_type, int)
+
+    def test_values_and_columns_have_equal_length(self):
+        _, values, columns = get_result_type_and_column(42)
+        assert len(values) == len(columns)
+
+    def test_always_returns_exactly_four_columns(self):
+        for sample in ["text", 1, 1.5, True, {"k": "v"}]:
+            _, values, columns = get_result_type_and_column(sample)
+            assert len(columns) == 4, f"Expected 4 columns for {sample!r}"
+            assert len(values) == 4, f"Expected 4 values for {sample!r}"
+
+
 class TestStringInput:
 
     def test_result_type_is_3(self):

--- a/test/test_utils_helper.py
+++ b/test/test_utils_helper.py
@@ -281,3 +281,36 @@ class TestInvalidInput:
         with pytest.raises(Exception, match="Cannot cast result to a valid type"):
             get_result_type_and_column(Foo())
 
+
+class TestColumnOrdering:
+    """The first column must always be the active (non-None) one,
+    since callers zip values and columns and expect this contract."""
+
+    def test_first_column_is_result_string_for_string(self):
+        _, _, columns = get_result_type_and_column("hello")
+        assert columns[0] == "resultString"
+
+    def test_first_column_is_result_json_for_dict(self):
+        _, _, columns = get_result_type_and_column({"k": "v"})
+        assert columns[0] == "resultJSON"
+
+    def test_first_column_is_result_boolean_for_bool(self):
+        _, _, columns = get_result_type_and_column(True)
+        assert columns[0] == "resultBoolean"
+
+    def test_first_column_is_result_number_for_int(self):
+        _, _, columns = get_result_type_and_column(42)
+        assert columns[0] == "resultNumber"
+
+    def test_first_column_is_result_number_for_float(self):
+        _, _, columns = get_result_type_and_column(3.14)
+        assert columns[0] == "resultNumber"
+
+    def test_first_value_is_never_none(self):
+        """value[0] must always be the actual payload, never None."""
+        cases = ["hello", {"k": "v"}, True, 42, 3.14]
+        for val in cases:
+            _, values, _ = get_result_type_and_column(val)
+            assert values[0] is not None, (
+                f"values[0] was None for input {val!r}"
+            )


### PR DESCRIPTION
## Summary

Adds tests for `get_result_type_and_column()` in `test/test_utils_helper.py`, building on existing tests from PR #40.

## Changes

- Refactored `safe_parse_datetime` and `extract_iot_id` tests into classes
- Converted bare `try/except` blocks into `pytest.raises`
- Added a new `assert_column_value` helper function
- Added 7 test classes that comprehensively test `get_result_type_and_column`

## Tests Added

- `TestReturnStructure` -> tests return structure, including shape and length
- `TestStringInput`, `TestDictInput`, `TestBoolInput`, `TestIntInput`, `TestFloatInput` -> tests input classification based on type
- `TestInvalidInput` -> tests that unsupported types correctly raise
- `TestColumnOrdering` -> tests that active column is always first

## Why These Tests Matter

- `get_result_type_and_column` has non-obvious contracts, including the `bool`/`int` ordering and column ordering, which are easy to break silently during refactoring
- These tests ensure that future changes do not break existing functionality

## Next Steps

If accepted, I intend to add tests for other helpers that are not currently covered — `validate_payload_keys`, `handle_associations`, `validate_epsg`, and `build_nextLink` — all of which are called on every PATCH/POST request.