### PR TITLE
fix(endpoints): remove stray parenthesis in SQL query and fix KeyError in update_feature_of_interest_entity

### DIFF
--- a/api/app/v1/endpoints/functions.py
+++ b/api/app/v1/endpoints/functions.py
@@ -125,6 +125,6 @@ async def update_datastream_observedArea(conn, datastream_id, feature_id=None):
                     )
                     UPDATE sensorthings."Datastream"
                     SET "observedArea" = (SELECT agg_geom FROM aggregated_geometry)
-                    WHERE id = $1;)
+                    WHERE id = $1;
                 """
             await conn.execute(query, datastream_id, feature_id)

--- a/api/app/v1/endpoints/update/functions.py
+++ b/api/app/v1/endpoints/update/functions.py
@@ -353,7 +353,7 @@ async def update_datastream_entity(connection, datastream_id, payload):
 async def update_feature_of_interest_entity(
     connection, feature_of_interest_id, payload
 ):
-    if payload["feature"]:
+    if payload.get("feature"):
         validate_epsg(payload["feature"])
 
     await handle_nested_entities(


### PR DESCRIPTION
## Summary

Fixes two issues identified in the update endpoint logic.

## Changes

- Fixed a stray `)` in the SQL query inside `update_datastream_observedArea` (`v1/endpoints/functions.py`).  
  The extra parenthesis after the query caused a PostgreSQL syntax error when the `ST_Extent` path was executed with a `feature_id`.

- Replaced direct access to `payload["feature"]` with `payload.get("feature")` in `update_feature_of_interest_entity` (`v1/endpoints/update/functions.py`).  
  The previous implementation raised a `KeyError` when PATCH requests did not include a `feature` field.

## Additional context

Both issues only appear under certain conditions:

- The SQL error occurs when `ST_AGGREGATE != "CONVEX_HULL"` and a `feature_id` is provided.
- The `KeyError` occurs when a partial PATCH request omits the `feature` field.