### PR TITLE
Validate secret key config

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -41,3 +41,6 @@ ALGORITHM = os.getenv("ALGORITHM", "HS256")
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 5))
 ANONYMOUS_VIEWER = int(os.getenv("ANONYMOUS_VIEWER", 0))
 NETWORK = int(os.getenv("NETWORK", 0))
+
+if AUTHORIZATION and SECRET_KEY is None:
+	raise ValueError("SECRET_KEY must be set when AUTHORIZATION is enabled")


### PR DESCRIPTION
## description
fixed the issue by adding fail-fast validation for missing `SECRET_KEY` when authorization is enabled

## problem
`SECRET_KEY` was loaded without validation, so the app could start with an invalid auth configuration and fail later at token creation with:
- `TypeError: Expected a string value`



## Changes
- added startup/config-time validation in `api/app/__init__.py`:
  - if `AUTHORIZATION` is enabled and `SECRET_KEY` is missing, raise:
    - ValueError("SECRET_KEY must be set when AUTHORIZATION is enabled")



### before 
- `AUTHORIZATION=1` with `SECRET_KEY` unset failed late at token issue path (`TypeError`).
<img width="1242" height="295" alt="image" src="https://github.com/user-attachments/assets/09c571e1-22fc-477a-885d-2deeb0804816" />




### after 
- `AUTHORIZATION=1` with `SECRET_KEY` unset fails fast at import/startup with clear `ValueError`.
- `AUTHORIZATION=0` with `SECRET_KEY` unset still imports successfully.
<img width="1156" height="136" alt="image" src="https://github.com/user-attachments/assets/de312fd8-c10e-4820-b194-9ab821bc2e6d" />


fix #145 
