### PR TITLE
fix:Check revocation on refresh

### DIFF
--- a/api/app/v1/endpoints/create/login.py
+++ b/api/app/v1/endpoints/create/login.py
@@ -71,6 +71,13 @@ async def refresh_token(authorization=Header()):
         )
     token = authorization[len(prefix) :].strip()
 
+    if redis.get(token) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has been revoked",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     try:
         payload = decode_token(token)
     except Exception:


### PR DESCRIPTION
## decription
fixes refresh-token revocation bypass by enforcing blacklist validation in `POST /Refresh`

**the changes that have been done**
  - updated `api/app/v1/endpoints/create/login.py`
  - added Redis revocation check before token decode/refresh issuance
  - returns 401 Unauthorized with **Token has been revoked** when blacklisted


### Before 
before the request, the status was 200, meaning everything was working normally
redis GET was not called, but redis SET was called to store data.

<img width="946" height="177" alt="image" src="https://github.com/user-attachments/assets/e571e469-7842-48fd-a172-e7698aed5f74" />




### After 
the HTTP request returned a 401 error, meaning the request was unauthorized bcz the token had been revoked
the system checked Redis using GET, but no data was written to Redis

<img width="946" height="177" alt="image" src="https://github.com/user-attachments/assets/a50d548c-a439-4b6e-8e8f-1002611729f2" />

fix #150


