### PR TITLE
Issue rbac role update

### DIFF
--- a/api/app/rbac_roles.py
+++ b/api/app/rbac_roles.py
@@ -1,0 +1,30 @@
+VALID_RBAC_ROLES = {
+    "viewer",
+    "editor",
+    "obs_manager",
+    "sensor",
+    "custom",
+}
+
+DB_ROLE_BY_RBAC_ROLE = {
+    "viewer": "user",
+    "editor": "user",
+    "obs_manager": "sensor",
+    "sensor": "sensor",
+    # Custom policies still require baseline schema/table permissions.
+    "custom": "user",
+}
+
+
+def validate_rbac_role(role: str) -> str:
+    clean_role = role.strip().lower()
+    if clean_role not in VALID_RBAC_ROLES:
+        raise ValueError(
+            "Invalid role. Supported roles are: "
+            + ", ".join(sorted(VALID_RBAC_ROLES))
+        )
+    return clean_role
+
+
+def get_db_role_for_rbac(role: str) -> str:
+    return DB_ROLE_BY_RBAC_ROLE[validate_rbac_role(role)]

--- a/api/app/v1/endpoints/create/user.py
+++ b/api/app/v1/endpoints/create/user.py
@@ -18,6 +18,7 @@ from app import HOSTNAME, POSTGRES_PORT_WRITE, SUBPATH, VERSION
 from app.utils.utils import pg_quote_ident, pg_quote_literal, validate_username
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
+from app.rbac_roles import get_db_role_for_rbac, validate_rbac_role
 from app.v1.endpoints.functions import insert_commit, set_role
 from asyncpg.exceptions import InsufficientPrivilegeError, UniqueViolationError
 from fastapi import APIRouter, Body, Depends, status
@@ -31,14 +32,6 @@ PAYLOAD_EXAMPLE = {
     "uri": "https://orcid.org/0000-0004-3456-7890",
     "role": "viewer",  # viewer, editor, obs_manager, sensor, custom
 }
-
-ROLES = {
-    "viewer": "user",
-    "editor": "user",
-    "obs_manager": "sensor",
-    "sensor": "sensor",
-}
-
 
 @v1.api_route(
     "/Users",
@@ -90,6 +83,14 @@ async def create_user(
                         },
                     )
 
+                try:
+                    payload["role"] = validate_rbac_role(payload["role"])
+                except ValueError as e:
+                    return JSONResponse(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        content={"message": str(e)},
+                    )
+
                 if current_user is not None:
                     if current_user["role"] != "administrator":
                         raise InsufficientPrivilegeError
@@ -135,14 +136,13 @@ async def create_user(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
-                if payload["role"] in ROLES:
-                    payload["role"] = ROLES[payload["role"]]
+                db_role = get_db_role_for_rbac(payload["role"])
 
                 await connection.execute(
                     "CREATE USER {} WITH ENCRYPTED PASSWORD {} IN ROLE {};".format(
                         pg_quote_ident(user["username"]),
                         pg_quote_literal(password),
-                        pg_quote_ident(payload["role"]),
+                        pg_quote_ident(db_role),
                     )
                 )
 

--- a/api/app/v1/endpoints/update/user.py
+++ b/api/app/v1/endpoints/update/user.py
@@ -17,6 +17,8 @@ import json
 from app import POSTGRES_PORT_WRITE
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
+from app.rbac_roles import get_db_role_for_rbac, validate_rbac_role
+from app.utils.utils import pg_quote_ident
 from app.utils.utils import validate_payload_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError, UndefinedObjectError
@@ -26,6 +28,7 @@ from fastapi.responses import JSONResponse, Response
 v1 = APIRouter()
 
 PAYLOAD_EXAMPLE = {
+    "role": "editor",
     "contact": {
         "email": "example@mail.com",
         "name": "example",
@@ -34,6 +37,7 @@ PAYLOAD_EXAMPLE = {
 }
 
 ALLOWED_KEYS = [
+    "role",
     "contact",
     "uri",
 ]
@@ -69,10 +73,10 @@ async def update_user(
                     await set_role(connection, current_user)
 
                 query = """
-                    SELECT username FROM sensorthings."User"
+                    SELECT username, role FROM sensorthings."User"
                     WHERE username = $1;
                 """
-                result = await connection.fetch(query, user)
+                result = await connection.fetchrow(query, user)
 
                 if not result:
                     return JSONResponse(
@@ -86,6 +90,16 @@ async def update_user(
                     return Response(status_code=status.HTTP_200_OK)
 
                 validate_payload_keys(payload, ALLOWED_KEYS)
+
+                previous_role = result["role"]
+                if "role" in payload:
+                    try:
+                        payload["role"] = validate_rbac_role(payload["role"])
+                    except ValueError as e:
+                        return JSONResponse(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            content={"message": str(e)},
+                        )
 
                 payload = {
                     key: (
@@ -104,6 +118,24 @@ async def update_user(
                     WHERE username = $1;
                 """
                 await connection.execute(query, user, *payload.values())
+
+                if "role" in payload and payload["role"] != previous_role:
+                    previous_db_role = get_db_role_for_rbac(previous_role)
+                    new_db_role = get_db_role_for_rbac(payload["role"])
+
+                    if previous_db_role != new_db_role:
+                        await connection.execute(
+                            "REVOKE {} FROM {};".format(
+                                pg_quote_ident(previous_db_role),
+                                pg_quote_ident(user),
+                            )
+                        )
+                        await connection.execute(
+                            "GRANT {} TO {};".format(
+                                pg_quote_ident(new_db_role),
+                                pg_quote_ident(user),
+                            )
+                        )
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")

--- a/api/tests/test_rbac_roles.py
+++ b/api/tests/test_rbac_roles.py
@@ -1,0 +1,25 @@
+import unittest
+
+from app.rbac_roles import get_db_role_for_rbac, validate_rbac_role
+
+
+class RbacRolesTestCase(unittest.TestCase):
+    def test_validate_role_accepts_supported_values(self):
+        self.assertEqual(validate_rbac_role("viewer"), "viewer")
+        self.assertEqual(validate_rbac_role("Editor"), "editor")
+        self.assertEqual(validate_rbac_role(" custom "), "custom")
+
+    def test_validate_role_rejects_unknown_value(self):
+        with self.assertRaisesRegex(ValueError, "Invalid role"):
+            validate_rbac_role("administrator")
+
+    def test_get_db_role_mapping(self):
+        self.assertEqual(get_db_role_for_rbac("viewer"), "user")
+        self.assertEqual(get_db_role_for_rbac("editor"), "user")
+        self.assertEqual(get_db_role_for_rbac("obs_manager"), "sensor")
+        self.assertEqual(get_db_role_for_rbac("sensor"), "sensor")
+        self.assertEqual(get_db_role_for_rbac("custom"), "user")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

This PR adds a small **RBAC-focused improvement**: administrators can now update a user role using `PATCH /Users`, with strict role validation and PostgreSQL role membership synchronization.

## Problem

User role changes previously required **delete-and-recreate workflows**.  
`PATCH /Users` could not handle role updates, making RBAC administration brittle and inconvenient.

## Changes

- Added shared **RBAC role utilities** in `rbac_roles.py`
- Added **strict role validation** in the user creation endpoint (`user.py`)
- Extended **PATCH user endpoint** to accept role updates in `user.py`
- Added **PostgreSQL role membership synchronization** when roles change
- Added focused tests in `test_rbac_roles.py`

## Supported RBAC Roles

- `viewer`
- `editor`
- `obs_manager`
- `sensor`
- `custom`

## Validation

- Unit tests for **role validation** and **role-to-database mapping** pass
- Existing **contact** and **uri** update behavior remains unchanged

## Why this helps the RBAC roadmap

This is a **small, review-friendly backend improvement** that enables practical **user role management for administrators**, supporting future RBAC features and workflows.


Closes #77 