### PR TITLE
fix: handle DELETE /Users self-delete and unexpected DB errors

### DIFF
--- a/api/app/v1/endpoints/delete/user.py
+++ b/api/app/v1/endpoints/delete/user.py
@@ -61,6 +61,12 @@ async def delete_user(
                     if current_user["role"] != "administrator":
                         raise InsufficientPrivilegeError
 
+                    if user == current_user["username"]:
+                        return JSONResponse(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            content={"message": "Cannot delete your own user account"},
+                        )
+
                     await set_role(connection, current_user)
 
                 query = """
@@ -94,11 +100,11 @@ async def delete_user(
         )
     except InsufficientPrivilegeError as e:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={"message": "Insufficient privileges"},
         )
     except Exception as e:
-        return Response(
+        return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content={"message": str(e)},
         )


### PR DESCRIPTION
## Title
DELETE /Users returns 500 Internal Server Error when deleting own account or on any unexpected DB error

---

## Description
When an authenticated admin calls `DELETE /Users?user=admin` (i.e., attempts to delete their own account), the server returns a **500 Internal Server Error** with a plain-text body instead of a proper JSON error response.

---

## Steps to Reproduce

1. Login as **admin** and obtain a **JWT token**
2. Call:

```
DELETE /Users?user=admin
```

with the **Bearer token**

3. The server returns:

```
500 Internal Server Error
```

---

## Expected Behavior

The API should return:

```
400 Bad Request
```

with a JSON response explaining that **deleting the currently authenticated user is not allowed**.

Example:

```json
{
  "detail": "Deleting the currently authenticated user is not allowed."
}
```

---

## Root Cause

Two issues exist in `user.py`:

1. The generic exception handler:

```python
except Exception:
```

returns:

```python
Response(content=dict)
```

However, `Response` does **not accept a dictionary**, which causes the error handler itself to fail. As a result, **uvicorn returns a raw 500 error** instead of a structured JSON response.

2. There is **no validation preventing a user from deleting their own account**, which can trigger a PostgreSQL error that falls into the broken exception handler.

---

## Screenshots



---
<img width="1956" height="1612" alt="image" src="https://github.com/user-attachments/assets/3ebe3e09-7d4a-4255-99a2-dbd144a9f415" />
