### PR TITLE
fix: handle DELETE /Users self-delete and unexpected DB errors

### DIFF
--- a/api/app/v1/endpoints/delete/user.py
+++ b/api/app/v1/endpoints/delete/user.py
@@ -61,6 +61,12 @@ async def delete_user(
                     if current_user["role"] != "administrator":
                         raise InsufficientPrivilegeError
 
+                    if user == current_user["username"]:
+                        return JSONResponse(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            content={"message": "Cannot delete your own user account"},
+                        )
+
                     await set_role(connection, current_user)
 
                 query = """
@@ -94,11 +100,11 @@ async def delete_user(
         )
     except InsufficientPrivilegeError as e:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={"message": "Insufficient privileges"},
         )
     except Exception as e:
-        return Response(
+        return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content={"message": str(e)},
         )


### PR DESCRIPTION
## Title
fix: return proper JSON error for DELETE /Users and prevent self-deletion

Fixes: #82

---

## Changes

- Added a **self-deletion guard**:  
  If the authenticated user tries to delete their own account, the API now returns:

  ```
  400 Bad Request
  ```

  with the response:

  ```json
  {
    "message": "Cannot delete your own user account"
  }
  ```

  This prevents the request from reaching the database.

- Fixed the generic exception handler:

  ```python
  except Exception:
  ```

  Replaced:

  ```python
  Response(content=dict)
  ```

  with:

  ```python
  JSONResponse(content=dict)
  ```

  `Response` does **not serialize dictionaries**, which previously caused the exception handler itself to crash, resulting in a secondary **500 Internal Server Error**.

  Using `JSONResponse` ensures proper JSON serialization and consistent API error responses.

---

<img width="1858" height="1404" alt="image" src="https://github.com/user-attachments/assets/d7740698-9a68-4e48-b7c1-5790b91dd4f8" />

## Result

- Prevents users from deleting their own accounts.
- Ensures API errors return proper **JSON responses instead of raw 500 errors**.
- Improves reliability of the `DELETE /Users` endpoint.