### PR TITLE
Fix/users update 404 message

### DIFF
--- a/api/app/v1/endpoints/update/user.py
+++ b/api/app/v1/endpoints/update/user.py
@@ -113,7 +113,7 @@ async def update_user(
     except UndefinedObjectError as e:
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
-            content={"message": "Policy not found"},
+            content={"message": "User not found"},
         )
     except InsufficientPrivilegeError as e:
         return JSONResponse(

--- a/api/tests/test_update_user_error_message.py
+++ b/api/tests/test_update_user_error_message.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+class UpdateUserErrorMessageTestCase(unittest.TestCase):
+    def test_update_user_undefined_object_message_is_user_not_found(self):
+        endpoint_file = (
+            Path(__file__).resolve().parents[1]
+            / "app"
+            / "v1"
+            / "endpoints"
+            / "update"
+            / "user.py"
+        )
+        content = endpoint_file.read_text(encoding="utf-8")
+
+        self.assertIn('except UndefinedObjectError as e:', content)
+        self.assertIn('content={"message": "User not found"}', content)
+        self.assertNotIn('content={"message": "Policy not found"}', content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

fixes incorrect 404 message in PATCH /Users
changes response text from Policy not found to User not found in [user.py:148]
adds regression coverage in [test_update_user_error_message.py:5]

## Why
PATCH /Users was returning a policy-oriented error message for a user endpoint, which is misleading for API clients and inconsistent with delete user behavior in [user.py:87]

## Changes
updated UndefinedObjectError handler message in [user.py:145]
added regression assertions to ensure:

1. User not found is present
2. Policy not found is absent
3. in [test_update_user_error_message.py:16]

## Validation
python3 -m unittest -q tests/test_update_user_error_message.py
python3 -m unittest -q tests/test_rbac_roles.py

## Scope
no behavior change outside PATCH /Users error message mapping
no schema, auth, or role logic changes

---
FIxes #85 