### PR TITLE
fix(api): replace deprecated Body example syntax

### DIFF
--- a/api/app/v1/endpoints/create/bulk_observation.py
+++ b/api/app/v1/endpoints/create/bulk_observation.py
@@ -79,7 +79,7 @@ PAYLOAD_EXAMPLE = [
     status_code=status.HTTP_201_CREATED,
 )
 async def bulk_observations(
-    payload: list = Body(example=PAYLOAD_EXAMPLE),
+    payload: list = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pgpool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/data_array_observation.py
+++ b/api/app/v1/endpoints/create/data_array_observation.py
@@ -99,7 +99,7 @@ PAYLOAD_EXAMPLE = [
     status_code=status.HTTP_201_CREATED,
 )
 async def data_array_observation(
-    payload: list = Body(example=PAYLOAD_EXAMPLE),
+    payload: list = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/datastream.py
+++ b/api/app/v1/endpoints/create/datastream.py
@@ -78,7 +78,7 @@ if AUTHORIZATION:
 )
 async def create_datastream(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -158,7 +158,7 @@ PAYLOAD_EXAMPLE_THING = {
 async def create_datastream_for_thing(
     request: Request,
     thing_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE_THING),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE_THING}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -243,7 +243,7 @@ PAYLOAD_EXAMPLE_SENSOR = {
 async def create_datastream_for_sensor(
     request: Request,
     sensor_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE_SENSOR),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE_SENSOR}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -331,7 +331,7 @@ PAYLOAD_EXAMPLE_OBSERVED_PROPERTY = {
 async def create_datastream_for_observed_property(
     request: Request,
     observed_property_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE_OBSERVED_PROPERTY),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE_OBSERVED_PROPERTY}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/feature_of_interest.py
+++ b/api/app/v1/endpoints/create/feature_of_interest.py
@@ -64,7 +64,7 @@ REQUIRED_KEYS = ["name", "encodingType", "feature"]
 )
 async def create_feature_of_interest(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/historical_location.py
+++ b/api/app/v1/endpoints/create/historical_location.py
@@ -54,7 +54,7 @@ ALLOWED_KEYS = [
 )
 async def create_historical_location(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -126,7 +126,7 @@ PAYLOAD_EXAMPLE_THING = {
 async def create_historical_location_for_thing(
     request: Request,
     thing_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE_THING),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE_THING}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/location.py
+++ b/api/app/v1/endpoints/create/location.py
@@ -64,7 +64,7 @@ REQUIRED_KEYS = ["name", "encodingType", "location"]
 )
 async def create_location(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -131,7 +131,7 @@ async def create_location(
 async def create_location_for_thing(
     request: Request,
     thing_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/network.py
+++ b/api/app/v1/endpoints/create/network.py
@@ -54,7 +54,7 @@ REQUIRED_KEYS = ["name"]
 )
 async def create_network(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/observation.py
+++ b/api/app/v1/endpoints/create/observation.py
@@ -65,7 +65,7 @@ ALLOWED_KEYS = [
 )
 async def create_observation(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -148,7 +148,7 @@ PAYLOAD_EXAMPLE_DATASTREAM = {
 async def create_observation_for_datastream(
     request: Request,
     datastream_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE_DATASTREAM),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE_DATASTREAM}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -229,7 +229,7 @@ async def create_observation_for_datastream(
 async def create_observation_for_feature_of_interest(
     request: Request,
     feature_of_interest_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/observed_property.py
+++ b/api/app/v1/endpoints/create/observed_property.py
@@ -62,7 +62,7 @@ REQUIRED_KEYS = ["name", "definition", "description"]
 )
 async def create_observed_property(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/policy.py
+++ b/api/app/v1/endpoints/create/policy.py
@@ -55,7 +55,7 @@ PAYLOAD_EXAMPLE = {
     status_code=status.HTTP_201_CREATED,
 )
 async def create_policy(
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     current_user=Depends(get_current_user),
     pgpool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):

--- a/api/app/v1/endpoints/create/sensor.py
+++ b/api/app/v1/endpoints/create/sensor.py
@@ -64,7 +64,7 @@ REQUIRED_KEYS = ["name", "encodingType", "metadata"]
 )
 async def create_sensor(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/thing.py
+++ b/api/app/v1/endpoints/create/thing.py
@@ -62,7 +62,7 @@ REQUIRED_KEYS = ["name"]
 )
 async def create_thing(
     request: Request,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
@@ -129,7 +129,7 @@ async def create_thing(
 async def create_thing_for_location(
     request: Request,
     location_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/create/user.py
+++ b/api/app/v1/endpoints/create/user.py
@@ -49,7 +49,7 @@ ROLES = {
     status_code=status.HTTP_201_CREATED,
 )
 async def create_user(
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     current_user=Depends(get_current_user),
     pgpool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):

--- a/api/app/v1/endpoints/update/datastream.py
+++ b/api/app/v1/endpoints/update/datastream.py
@@ -75,7 +75,7 @@ if AUTHORIZATION:
 )
 async def update_datastream(
     datastream_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/feature_of_interest.py
+++ b/api/app/v1/endpoints/update/feature_of_interest.py
@@ -70,7 +70,7 @@ ALLOWED_KEYS = [
 )
 async def update_feature_of_interest(
     feature_of_interest_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/historical_location.py
+++ b/api/app/v1/endpoints/update/historical_location.py
@@ -54,7 +54,7 @@ ALLOWED_KEYS = ["time", "Thing", "Locations"]
 )
 async def update_historical_location(
     historical_location_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/location.py
+++ b/api/app/v1/endpoints/update/location.py
@@ -62,7 +62,7 @@ ALLOWED_KEYS = [
 )
 async def update_location(
     location_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/network.py
+++ b/api/app/v1/endpoints/update/network.py
@@ -51,7 +51,7 @@ ALLOWED_KEYS = ["name", "Datastreams"]
 )
 async def update_network(
     network_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/observation.py
+++ b/api/app/v1/endpoints/update/observation.py
@@ -64,7 +64,7 @@ ALLOWED_KEYS = [
 )
 async def update_observation(
     observation_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/observed_property.py
+++ b/api/app/v1/endpoints/update/observed_property.py
@@ -64,7 +64,7 @@ ALLOWED_KEYS = [
 )
 async def update_observed_property(
     observed_property_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/policy.py
+++ b/api/app/v1/endpoints/update/policy.py
@@ -44,7 +44,7 @@ async def update_policy(
         alias="policy",
         description="The name of the policy to update",
     ),
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     current_user=Depends(get_current_user),
     pgpool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):

--- a/api/app/v1/endpoints/update/sensor.py
+++ b/api/app/v1/endpoints/update/sensor.py
@@ -62,7 +62,7 @@ ALLOWED_KEYS = [
 )
 async def update_sensor(
     sensor_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/thing.py
+++ b/api/app/v1/endpoints/update/thing.py
@@ -60,7 +60,7 @@ ALLOWED_KEYS = [
 )
 async def update_thing(
     thing_id: int,
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     commit_message=message,
     current_user=user,
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),

--- a/api/app/v1/endpoints/update/user.py
+++ b/api/app/v1/endpoints/update/user.py
@@ -52,7 +52,7 @@ async def update_user(
         alias="user",
         description="The the user to update",
     ),
-    payload: dict = Body(example=PAYLOAD_EXAMPLE),
+    payload: dict = Body(examples={"default": {"value": PAYLOAD_EXAMPLE}}),
     current_user=Depends(get_current_user),
     pgpool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):


### PR DESCRIPTION
## description
many create/update endpoints still use deprecated FastAPI request-body syntax `Body(example=...)`. 
this PR migrates these to `Body(examples=...)` to remove deprecation usage and reduce upgrade risk.

updated files under:
 api/app/v1/endpoints/create/**
api/app/v1/endpoints/update/**

## Before Fix
- Deprecated occurrences in endpoints: **32**
<img width="1172" height="217" alt="image" src="https://github.com/user-attachments/assets/fef69d60-2e56-4632-9330-18ee28448196" />



## After Fix
- All endpoint occurrences were migrated from `Body(example=...)` to `Body(examples={"default": {"value": ...}})`.
<img width="1172" height="217" alt="image" src="https://github.com/user-attachments/assets/0ccf3056-74ab-451a-8b1c-5d6f84727939" />
