### PR TITLE
fix(RBAC): validate SET ROLE identifiers

### DIFF
--- a/api/app/v1/endpoints/create/data_array_observation.py
+++ b/api/app/v1/endpoints/create/data_array_observation.py
@@ -24,6 +24,7 @@ from app import (
     VERSIONING,
 )
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.v1.endpoints.functions import set_role
 from app.utils.utils import (
     check_iot_id_in_payload,
     check_missing_properties,
@@ -110,10 +111,7 @@ async def data_array_observation(
         async with pool.acquire() as conn:
             async with conn.transaction():
                 if current_user is not None:
-                    query = 'SET ROLE "{username}";'
-                    await conn.execute(
-                        query.format(username=current_user["username"])
-                    )
+                    await set_role(conn, current_user)
 
                 try:
                     commit_id = await set_commit(

--- a/api/app/v1/endpoints/functions.py
+++ b/api/app/v1/endpoints/functions.py
@@ -13,14 +13,23 @@
 # limitations under the License.
 
 import json
+import re
 from app import EPSG, ST_AGGREGATE
+
+
+_PG_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_role_identifier(username: str) -> str:
+    if not isinstance(username, str) or not _PG_IDENTIFIER_RE.match(username):
+        raise ValueError("Invalid role identifier")
+    return username
 
 async def set_role(connection, current_user):
     async with connection.transaction():
+        username = _validate_role_identifier(current_user["username"])
         query = 'SET ROLE "{username}";'
-        await connection.execute(
-            query.format(username=current_user["username"])
-        )
+        await connection.execute(query.format(username=username))
 
 
 async def insert_commit(connection, payload, action):


### PR DESCRIPTION
## Description
RBAC role switching is built with string formatting in critical authorization paths. This allows malformed role strings to be injected into the SQL text and creates inconsistent role-switch safety across endpoints.
closes #89

before the fix:
<img width="1172" height="217" alt="image" src="https://github.com/user-attachments/assets/0af55546-f19a-4109-8ed5-0785e968bcf2" />


after the fix:
<img width="1172" height="217" alt="image" src="https://github.com/user-attachments/assets/29322e98-23ba-471a-af3d-4a43c1b32f8e" />
