### PR TITLE
fix: improve validation and error messages for malformed $from_to queries

### DIFF
--- a/api/app/sta2rest/sta_parser/parser.py
+++ b/api/app/sta2rest/sta_parser/parser.py
@@ -277,9 +277,21 @@ class Parser:
             ast.FromToNode: The parsed fromto expression.
         """
         self.match("FROMTO")
+        if not self.current_token or self.current_token.type != "DATETIME":
+            raise Exception(
+                "Invalid $from_to: expected format is $from_to=<start>/<end>"
+            )
         value1 = self.current_token.value
         self.match("DATETIME")
+        if not self.current_token or self.current_token.type != "SEGMENT_SEPARATOR":
+            raise Exception(
+                "Invalid $from_to: missing end datetime, use $from_to=<start>/<end>"
+            )
         self.match("SEGMENT_SEPARATOR")
+        if not self.current_token or self.current_token.type != "DATETIME":
+            raise Exception(
+                "Invalid $from_to: missing end datetime after '/'"
+            )
         value2 = self.current_token.value
         self.match("DATETIME")
         return ast.FromToNode(value1, value2)


### PR DESCRIPTION
## Related Issue
Closes #91 

## Problem
When a `$from_to` query parameter was provided with only a single datetime (instead of a full ISO 8601 interval like `<start>/<end>`), the parser would crash while attempting to find the missing separator.
This resulted in a cryptic **400 Bad Request** response with the message:
`'NoneType' object has no attribute 'type'`


## Solution

Implemented explicit validation guards in the `parse_fromto` method of the query parser.

### Improvements

- **Missing End Datetime Detection**  
  The parser now checks for the presence of the `/` separator and the second datetime.

- **Human-Readable Errors**  
  Replaced the generic Python crash with clear, concise error messages explaining what is missing.

- **Shortened Messages**  
  Optimized message length for better compatibility with UI tools such as Swagger.

---

## Changes Made

**File:**  
`api/app/sta2rest/sta_parser/parser.py`

**Modification:**

- Added guard clauses in `parse_fromto` to validate the token stream before matching.

---

## Verification

| Scenario | Before | After |
|--------|--------|--------|
| `$from_to=2026-12-01...` (Missing `/`) | `400` + `'NoneType' object...` | `400` + `Invalid $from_to: missing end datetime...` |
| `$from_to=2026-01-01/` (Missing end) | `400` + `'NoneType' object...` | `400` + `Invalid $from_to: missing end datetime after '/'` |

---

## Before

```json
{
  "code": 400,
  "type": "error",
  "message": "'NoneType' object has no attribute 'type'"
}
```

## After
```json
{
  "code": 400,
  "type": "error",
  "message": "Invalid $from_to: missing end datetime, use $from_to=<start>/<end>"
}
```