### PR TITLE
fix(create_entity): correct geometry placeholder condition

### DIFF
--- a/api/app/v1/endpoints/create/functions.py
+++ b/api/app/v1/endpoints/create/functions.py
@@ -72,7 +72,7 @@ async def create_entity(connection, entity_name, payload):
         values_placeholders = ", ".join(
             (
                 f"${i+1}"
-                if key != "location" or key != "feature"
+                if key != "location" and key != "feature"
                 else f"ST_GeomFromGeoJSON(${i+1})"
             )
             for i in range(len(payload))


### PR DESCRIPTION
Resolves the bug identified and documented in #94.

The placeholder condition on line 75 of `create/functions.py` was using `or` instead of `and`. This meant that `ST_GeomFromGeoJSON()` was never actually used in the generated INSERT query, even when the columns were geometry types like `location` or `feature`.

### The fix

A simple change from or to and because a string can not be both feature and location at the same time

### Proof

Both of the tests that were failing in #94 now pass with this change.
Screenshot of the failure is attached below -> all 26 tests green after fix.

<img width="1913" height="952" alt="Screenshot 2026-03-18 124846" src="https://github.com/user-attachments/assets/0b67583b-bd1b-4edf-b8d1-327e7e88606c" />

### Tests

No additional tests were needed. The tests in `test/test_create_functions.py` (`test_location_key_uses_st_geomfromgeojson`, `test_feature_key_uses_st_geomfromgeojson`) are the tests that were failing, and now pass with this change.