### PR TITLE
fix(rbac): safely quote username in SET ROLE

### DIFF
--- a/api/app/v1/endpoints/functions.py
+++ b/api/app/v1/endpoints/functions.py
@@ -15,14 +15,13 @@
 import json
 
 from app import ST_AGGREGATE
+from app.utils.utils import pg_quote_ident
 
 
 async def set_role(connection, current_user):
     async with connection.transaction():
-        query = 'SET ROLE "{username}";'
-        await connection.execute(
-            query.format(username=current_user["username"])
-        )
+        query = f"SET ROLE {pg_quote_ident(current_user['username'])};"
+        await connection.execute(query)
 
 
 async def insert_commit(connection, payload, action):

--- a/api/tests/test_set_role_sql_safety.py
+++ b/api/tests/test_set_role_sql_safety.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+# Ensure api/ is on sys.path so 'app' resolves to api/app
+API_DIR = str(Path(__file__).resolve().parents[1])
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+# Patch env vars before importing app
+os.environ.setdefault("ISTSOS_ADMIN", "admin")
+os.environ.setdefault("ISTSOS_ADMIN_PASSWORD", "secret")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "istsos")
+os.environ.setdefault("POSTGRES_USER", "admin")
+
+from app.v1.endpoints.functions import set_role  # noqa: E402
+
+
+class DummyConnection:
+    def __init__(self):
+        self.execute = AsyncMock()
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield
+
+
+def test_set_role_escapes_identifier_quotes():
+    conn = DummyConnection()
+    current_user = {"username": 'bad"name'}
+
+    asyncio.run(set_role(conn, current_user))
+
+    conn.execute.assert_awaited_once_with('SET ROLE "bad""name";')


### PR DESCRIPTION
Description:
## What changed
Updated SET ROLE SQL construction to safely quote PostgreSQL role identifier in functions.py.
Added regression test for quoted-identifier behavior in test_set_role_sql_safety.py
## Why
The RBAC role-switch helper should treat username as a PostgreSQL identifier. Safe quoting prevents malformed SQL and hardens this central auth path for edge-case usernames.

## Scope
No API contract changes.
No RBAC policy logic changes.
Small internal security hardening in shared helper.

## Testing
Added focused test asserting SET ROLE SQL for username containing double quote.

## Risk
Low. Change is limited to identifier quoting in existing helper and is covered by targeted regression test.


---

FIxes #96 