### PR TITLE
refactor: replace raw parser.parse() calls with safe_parse_datetime()

### DIFF
--- a/api/app/v1/endpoints/create/bulk_observation.py
+++ b/api/app/v1/endpoints/create/bulk_observation.py
@@ -15,10 +15,10 @@
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
+from app.utils.utils import safe_parse_datetime
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from asyncpg.types import Range
-from dateutil import parser
 from fastapi import APIRouter, Body, Depends, Header, status
 from fastapi.responses import JSONResponse, Response
 
@@ -233,7 +233,7 @@ async def insertBulkObservation(
         ph_interval = None
         for obs in payload:
             if result_time_idx > -1:
-                obs[result_time_idx] = parser.parse(obs[result_time_idx])
+                obs[result_time_idx] = safe_parse_datetime(obs[result_time_idx])
             if "/" in obs[ph_idx]:
                 ph_time = obs[ph_idx].split("/")
                 obs[ph_idx] = Range(
@@ -254,7 +254,7 @@ async def insertBulkObservation(
                     upper_inc=True,
                 )
             else:
-                if parser.parse(ph_interval.lower) > parser.parse(
+                if safe_parse_datetime(ph_interval.lower) > safe_parse_datetime(
                     obs[ph_idx].lower
                 ):
                     ph_interval = Range(
@@ -262,7 +262,7 @@ async def insertBulkObservation(
                         ph_interval.upper,
                         upper_inc=True,
                     )
-                if parser.parse(ph_interval.upper) < parser.parse(
+                if safe_parse_datetime(ph_interval.upper) < safe_parse_datetime(
                     obs[ph_idx].upper
                 ):
                     ph_interval = Range(
@@ -271,8 +271,8 @@ async def insertBulkObservation(
                         upper_inc=True,
                     )
             obs[ph_idx] = Range(
-                parser.parse(obs[ph_idx].lower),
-                parser.parse(obs[ph_idx].upper),
+                safe_parse_datetime(obs[ph_idx].lower),
+                safe_parse_datetime(obs[ph_idx].upper),
                 upper_inc=True,
             )
 
@@ -283,8 +283,8 @@ async def insertBulkObservation(
 
             data.append(obs + default_obs)
         ph_interval = Range(
-            parser.parse(ph_interval.lower),
-            parser.parse(ph_interval.upper),
+            safe_parse_datetime(ph_interval.lower),
+            safe_parse_datetime(ph_interval.upper),
             upper_inc=True,
         )
 


### PR DESCRIPTION
### Context
Reference to my merged PR #40 , I implemented the safe_parse_datetime function to improve exception handling.

### Code
Replaces 6 instances of raw parser.parse() usages in bulk_observation.py, removes import of parser from dateutil.