### PR TITLE
Fix multi-user custom policy role targets and add regression test

### DIFF
--- a/api/app/v1/endpoints/create/policy.py
+++ b/api/app/v1/endpoints/create/policy.py
@@ -15,6 +15,7 @@
 from app import POSTGRES_PORT_WRITE
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
+from app.utils.utils import pg_quote_ident
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import DuplicateObjectError, InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, status
@@ -168,7 +169,7 @@ async def create_policies(connection, users, policies, name):
         "observation": "Observation",
         "featuresofinterest": "FeaturesOfInterest",
     }
-    users = ", ".join(users)
+    roles_sql = ", ".join(pg_quote_ident(user) for user in users)
     for table, operations in policies.items():
         table = table_mapping.get(table)
 
@@ -178,7 +179,7 @@ async def create_policies(connection, users, policies, name):
                     CREATE POLICY "{name}_{table.lower()}_{operation}"
                     ON sensorthings."{table}"
                     FOR {operation}
-                    TO "{users}"
+                    TO {roles_sql}
                     USING ({condition});
                 """
             else:
@@ -187,7 +188,7 @@ async def create_policies(connection, users, policies, name):
                         CREATE POLICY "{name}_{table.lower()}_{operation}"
                         ON sensorthings."{table}"
                         FOR {operation}
-                        TO "{users}"
+                        TO {roles_sql}
                         WITH CHECK ({condition});
                     """
                 else:
@@ -195,7 +196,7 @@ async def create_policies(connection, users, policies, name):
                         CREATE POLICY "{name}_{table.lower()}_{operation}"
                         ON sensorthings."{table}"
                         FOR {operation}
-                        TO "{users}"
+                        TO {roles_sql}
                         USING ({condition})
                         WITH CHECK ({condition});
                     """

--- a/api/tests/test_policy_create_multi_user.py
+++ b/api/tests/test_policy_create_multi_user.py
@@ -1,0 +1,57 @@
+"""Regression tests for custom policy role target generation."""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from unittest.mock import AsyncMock
+
+
+# Ensure api/ is on sys.path so 'app' resolves to api/app
+API_DIR = str(Path(__file__).resolve().parents[1])
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+# Provide minimal env vars before importing app modules.
+os.environ.setdefault("SECRET_KEY", "test_secret_key")
+
+import app.v1.endpoints.create.policy as create_policy_endpoint  # noqa: E402
+
+
+def _run_create_policies(users):
+    """Execute create_policies and return emitted SQL statements."""
+    connection = AsyncMock()
+    connection.execute = AsyncMock()
+
+    policies = {"datastream": {"select": "true"}}
+
+    asyncio.run(
+        create_policy_endpoint.create_policies(
+            connection=connection,
+            users=users,
+            policies=policies,
+            name="rbac_test",
+        )
+    )
+
+    return [call.args[0] for call in connection.execute.await_args_list]
+
+
+def test_create_policies_multi_user_targets_are_separate_roles():
+    """Multiple users must be rendered as separate quoted role identifiers."""
+    statements = _run_create_policies(["alice", "bob"])
+
+    assert len(statements) == 1
+    sql = statements[0]
+    assert 'TO "alice", "bob"' in sql
+    assert 'TO "alice, bob"' not in sql
+
+
+def test_create_policies_single_user_target_still_valid():
+    """Single-user policy generation should remain unchanged and valid."""
+    statements = _run_create_policies(["alice"])
+
+    assert len(statements) == 1
+    sql = statements[0]
+    assert 'TO "alice"' in sql


### PR DESCRIPTION

## Summary
This PR fixes custom policy creation when assigning a policy to multiple users.

Previously, the role list was built as a single quoted string (for example, "alice, bob"), which PostgreSQL treats as one role identifier.
Now each role is quoted and emitted separately (for example, "alice", "bob"), so CREATE POLICY targets all intended users correctly.

## Changes
Updated custom policy SQL role target generation in [policy.py](vscode-file://vscode-app/c:/Users/bhanp/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added safe identifier quoting import and usage for role names
Added regression tests in [test_policy_create_multi_user.py](vscode-file://vscode-app/c:/Users/bhanp/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
## Why this matters
Fixes incorrect/failed RBAC policy assignment in multi-user scenarios
Prevents future regressions with explicit test coverage
Improves reliability for open-source multi-user deployments
## Tests
Added:

test_create_policies_multi_user_targets_are_separate_roles
test_create_policies_single_user_target_still_valid


---

Fixes #103 