### PR TITLE
fix(rbac): require auth for /Users endpoint when AUTHORIZATION=1

### DIFF
--- a/api/app/v1/endpoints/read/user.py
+++ b/api/app/v1/endpoints/read/user.py
@@ -25,7 +25,7 @@ v1 = APIRouter()
 
 user = Header(default=None, include_in_schema=False)
 
-if AUTHORIZATION and not ANONYMOUS_VIEWER:
+if AUTHORIZATION:
     from app.oauth import get_current_user
 
     user = Depends(get_current_user)


### PR DESCRIPTION
## Problem
When AUTHORIZATION=1 and  ANONYMOUS_VIEWER=1, /Users could be queried without authentication because the endpoint only bound `get_current_user` when anonymous viewer was disabled.

the reason for this is because:
in `api/app/v1/endpoints/read/user.py`, dependency binding used:
if AUTHORIZATION and not ANONYMOUS_VIEWER: user = Depends(get_current_user)
This left **current_user=None** in anonymous mode and skipped admin role checks.

## the changes that were made
updated dependency binding to:

`if AUTHORIZATION: user = Depends(get_current_user)`

this keeps /Users authenticated regardless of anonymous public-read mode.


### before the fix:
<img width="1320" height="186" alt="image" src="https://github.com/user-attachments/assets/682038a3-6186-42db-a3bf-76fb43132a91" />

