### PR TITLE
feat(conformance): add GET /Conformance endpoint per OGC STA 1.1 spec

### DIFF
--- a/api/app/v1/api.py
+++ b/api/app/v1/api.py
@@ -49,6 +49,7 @@ from app.v1.endpoints.delete import policy as delete_policy
 from app.v1.endpoints.delete import sensor as delete_sensor
 from app.v1.endpoints.delete import thing as delete_thing
 from app.v1.endpoints.delete import user as delete_user
+from app.v1.endpoints.read import conformance as read_conformance
 from app.v1.endpoints.read import datastream as read_datastream
 from app.v1.endpoints.read import (
     feature_of_interest as read_feature_of_interest,
@@ -143,6 +144,10 @@ tags_metadata += [
         "name": "Observations",
         "description": "Individual measurements recorded at a given point in time.",
     },
+    {
+        "name": "Conformance",
+        "description": "OGC SensorThings API 1.1 conformance classes implemented by this server.",
+    },
 ]
 
 v1 = FastAPI(
@@ -173,6 +178,7 @@ if NETWORK:
     v1.include_router(delete_network.v1)
 
 # Register the read endpoints
+v1.include_router(read_conformance.v1)
 v1.include_router(read_location.v1)
 v1.include_router(read_thing.v1)
 v1.include_router(read_historical_location.v1)

--- a/api/app/v1/endpoints/read/conformance.py
+++ b/api/app/v1/endpoints/read/conformance.py
@@ -27,6 +27,18 @@ v1 = APIRouter()
     status_code=status.HTTP_200_OK,
 )
 async def get_conformance():
+    """
+    Return the OGC SensorThings API 1.1 conformance classes.
+
+    The conformance list declares which parts of the STA specification
+    this server implements. Metadata connectors such as DCAT-AP and STAC
+    harvesters use this endpoint to populate dcat:endpointDescription
+    and dct:conformsTo without parsing the root response.
+
+    Returns:
+        JSONResponse: A JSON object with a 'value' key containing
+        the list of conformance class URIs.
+    """
     try:
         return JSONResponse(
             status_code=status.HTTP_200_OK,

--- a/api/app/v1/endpoints/read/conformance.py
+++ b/api/app/v1/endpoints/read/conformance.py
@@ -1,0 +1,39 @@
+# Copyright 2025 SUPSI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from app.settings import serverSettings
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
+
+v1 = APIRouter()
+
+@v1.api_route(
+    "/Conformance",
+    methods=["GET"],
+    tags=["Conformance"],
+    summary="Get conformance classes",
+    description="Returns the list of OGC SensorThings API 1.1 conformance classes implemented by this server. This endpoint is required by the OGC STA 1.1 specification and enables metadata connectors to discover service capabilities programmatically.",
+    status_code=status.HTTP_200_OK,
+)
+async def get_conformance():
+    try:
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={"value": serverSettings["conformance"]},
+        )
+    except Exception:
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"message": "Failed to retrieve conformance classes."},
+        )


### PR DESCRIPTION
### The need
The OGC SensorThings API 1.1 spec states that a dedicated `/Conformance` endpoint is required, which returns the list of implemented conformance classes. I couldn't find it, but the conformance list exists in `serverSettings` (in api/app/settings.py) and is only accessed embedded inside the root response by the `__handle_root()` function in both `main.py` (api/app/main.py) and `read.py` (v1/endpoints/read/read.py).

### Changes
This PR does just that, adds a conformance endpoint which will make it STA spec compliant as well as help the DCAT-AP metadata connector, which is in the GSoC Ideas list (for `dcat:endpointDescription`, etc.). I made sure to make the endpoints exactly like the other endpoints for clear readability.