### PR TITLE
Harden RBAC: enforce SET ROLE/RESET ROLE in policy create and update

### DIFF
--- a/api/app/v1/endpoints/create/policy.py
+++ b/api/app/v1/endpoints/create/policy.py
@@ -65,6 +65,7 @@ async def create_policy(
 
         async with pgpool.acquire() as connection:
             async with connection.transaction():
+                role_switched = False
                 if (
                     "users" not in payload
                     or "name" not in payload
@@ -81,63 +82,70 @@ async def create_policy(
                     if current_user["role"] != "administrator":
                         raise InsufficientPrivilegeError
 
-                permission_type = payload["permissions"].get("type")
+                    await set_role(connection, current_user)
+                    role_switched = True
 
-                for user in payload["users"]:
-                    query = f"""
-                        SELECT COUNT(*)
-                        FROM pg_policies
-                        WHERE $1 = ANY (roles)
-                    """
-                    result = await connection.fetchval(query, user)
-                    if result > 0:
-                        raise Exception(f"User {user} has already a policy.")
+                try:
+                    permission_type = payload["permissions"].get("type")
 
-                    query = f"""
-                        SELECT role
-                        FROM sensorthings."User"
-                        WHERE username = $1
-                    """
-                    result = await connection.fetchval(query, user)
-                    if (
-                        permission_type != "custom"
-                        and result != permission_type
-                    ):
-                        raise Exception(
-                            f"User {user} has a different role than the policy type."
+                    for user in payload["users"]:
+                        query = f"""
+                            SELECT COUNT(*)
+                            FROM pg_policies
+                            WHERE $1 = ANY (roles)
+                        """
+                        result = await connection.fetchval(query, user)
+                        if result > 0:
+                            raise Exception(f"User {user} has already a policy.")
+
+                        query = f"""
+                            SELECT role
+                            FROM sensorthings."User"
+                            WHERE username = $1
+                        """
+                        result = await connection.fetchval(query, user)
+                        if (
+                            permission_type != "custom"
+                            and result != permission_type
+                        ):
+                            raise Exception(
+                                f"User {user} has a different role than the policy type."
+                            )
+
+                    if permission_type == "custom":
+                        await create_policies(
+                            connection,
+                            payload["users"],
+                            payload["permissions"]["policy"],
+                            payload["name"],
                         )
-
-                if permission_type == "custom":
-                    await create_policies(
-                        connection,
-                        payload["users"],
-                        payload["permissions"]["policy"],
-                        payload["name"],
-                    )
-                elif permission_type == "viewer":
-                    await connection.execute(
-                        f"SELECT sensorthings.viewer_policy($1, $2);",
-                        payload["users"],
-                        payload["name"],
-                    )
-                elif permission_type == "editor":
-                    await connection.execute(
-                        f"SELECT sensorthings.editor_policy($1, $2);",
-                        payload["users"],
-                        payload["name"],
-                    )
-                elif permission_type == "obs_manager":
-                    await connection.execute(
-                        f"SELECT sensorthings.obs_manager_policy($1, $2);",
-                        payload["users"],
-                        payload["name"],
-                    )
-                elif permission_type == "sensor":
-                    await connection.execute(
-                        f"SELECT sensorthings.sensor_policy($1, $2);",
-                        payload["users"],
-                        payload["name"],
-                    )
+                    elif permission_type == "viewer":
+                        await connection.execute(
+                            f"SELECT sensorthings.viewer_policy($1, $2);",
+                            payload["users"],
+                            payload["name"],
+                        )
+                    elif permission_type == "editor":
+                        await connection.execute(
+                            f"SELECT sensorthings.editor_policy($1, $2);",
+                            payload["users"],
+                            payload["name"],
+                        )
+                    elif permission_type == "obs_manager":
+                        await connection.execute(
+                            f"SELECT sensorthings.obs_manager_policy($1, $2);",
+                            payload["users"],
+                            payload["name"],
+                        )
+                    elif permission_type == "sensor":
+                        await connection.execute(
+                            f"SELECT sensorthings.sensor_policy($1, $2);",
+                            payload["users"],
+                            payload["name"],
+                        )
+                finally:
+                    if role_switched:
+                        await connection.execute("RESET ROLE;")
         return Response(status_code=status.HTTP_201_CREATED)
 
     except DuplicateObjectError:

--- a/api/app/v1/endpoints/update/policy.py
+++ b/api/app/v1/endpoints/update/policy.py
@@ -52,59 +52,63 @@ async def update_policy(
 
         async with pgpool.acquire() as connection:
             async with connection.transaction():
+                role_switched = False
                 if current_user is not None:
                     if current_user["role"] != "administrator":
                         raise InsufficientPrivilegeError
+                    await set_role(connection, current_user)
+                    role_switched = True
 
-                validate_payload_keys(payload, ALLOWED_KEYS)
+                try:
+                    validate_payload_keys(payload, ALLOWED_KEYS)
 
-                if payload.get("users") is not None:
-                    query = """
-                        SELECT sensorthings.add_users_to_policy($1, $2);
-                    """
-                    tablename, cmd = await connection.fetchval(
-                        query, payload["users"], policy
-                    )
-                else:
-                    query = """
-                        SELECT tablename, cmd FROM pg_policies
-                        WHERE policyname = $1;
-                    """
-                    row = await connection.fetchrow(query, policy)
-                    if row is None:
-                        raise Exception(f"Policy '{policy}' not found.")
+                    if payload.get("users") is not None:
+                        query = """
+                            SELECT sensorthings.add_users_to_policy($1, $2);
+                        """
+                        tablename, cmd = await connection.fetchval(
+                            query, payload["users"], policy
+                        )
+                    else:
+                        query = """
+                            SELECT tablename, cmd FROM pg_policies
+                            WHERE policyname = $1;
+                        """
+                        row = await connection.fetchrow(query, policy)
+                        if row is None:
+                            raise Exception(f"Policy '{policy}' not found.")
 
-                    tablename, cmd = row["tablename"], row["cmd"]
+                        tablename, cmd = row["tablename"], row["cmd"]
 
-                if payload.get("policy") is not None:
-                    policy_sql = {
-                        "SELECT": 'ALTER POLICY {} ON sensorthings."{}" USING ({});'.format(
-                            policy, tablename, payload["policy"]
-                        ),
-                        "INSERT": 'ALTER POLICY {} ON sensorthings."{}" WITH CHECK ({});'.format(
-                            policy, tablename, payload["policy"]
-                        ),
-                        "UPDATE": 'ALTER POLICY {} ON sensorthings."{}" USING ({}) WITH CHECK ({});'.format(
-                            policy,
-                            tablename,
-                            payload["policy"],
-                            payload["policy"],
-                        ),
-                        "DELETE": 'ALTER POLICY {} ON sensorthings."{}" USING ({});'.format(
-                            policy, tablename, payload["policy"]
-                        ),
-                        "ALL": 'ALTER POLICY {} ON sensorthings."{}" USING ({}) WITH CHECK ({});'.format(
-                            policy,
-                            tablename,
-                            payload["policy"],
-                            payload["policy"],
-                        ),
-                    }.get(cmd)
+                    if payload.get("policy") is not None:
+                        policy_sql = {
+                            "SELECT": 'ALTER POLICY {} ON sensorthings."{}" USING ({});'.format(
+                                policy, tablename, payload["policy"]
+                            ),
+                            "INSERT": 'ALTER POLICY {} ON sensorthings."{}" WITH CHECK ({});'.format(
+                                policy, tablename, payload["policy"]
+                            ),
+                            "UPDATE": 'ALTER POLICY {} ON sensorthings."{}" USING ({}) WITH CHECK ({});'.format(
+                                policy,
+                                tablename,
+                                payload["policy"],
+                                payload["policy"],
+                            ),
+                            "DELETE": 'ALTER POLICY {} ON sensorthings."{}" USING ({});'.format(
+                                policy, tablename, payload["policy"]
+                            ),
+                            "ALL": 'ALTER POLICY {} ON sensorthings."{}" USING ({}) WITH CHECK ({});'.format(
+                                policy,
+                                tablename,
+                                payload["policy"],
+                                payload["policy"],
+                            ),
+                        }.get(cmd)
 
-                    await connection.execute(policy_sql)
-
-                if current_user is not None:
-                    await connection.execute("RESET ROLE;")
+                        await connection.execute(policy_sql)
+                finally:
+                    if role_switched:
+                        await connection.execute("RESET ROLE;")
 
         return Response(status_code=status.HTTP_200_OK)
 

--- a/api/tests/test_policy_role_switch.py
+++ b/api/tests/test_policy_role_switch.py
@@ -1,0 +1,92 @@
+"""Tests for DB role switching in policy admin endpoints."""
+
+import asyncio
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+
+# Ensure api/ is on sys.path so 'app' resolves to api/app
+API_DIR = str(Path(__file__).resolve().parents[1])
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+os.environ.setdefault("SECRET_KEY", "test_secret_key")
+
+import app.v1.endpoints.create.policy as create_policy_endpoint  # noqa: E402
+import app.v1.endpoints.update.policy as update_policy_endpoint  # noqa: E402
+
+
+def _mock_pgpool(connection):
+    @asynccontextmanager
+    async def _acquire():
+        yield connection
+
+    class _Pool:
+        def acquire(self):
+            return _acquire()
+
+    return _Pool()
+
+
+def _attach_transaction_cm(connection):
+    @asynccontextmanager
+    async def _tx():
+        yield
+
+    connection.transaction = _tx
+
+
+def test_create_policy_sets_and_resets_role_for_admin():
+    connection = AsyncMock()
+    connection.execute = AsyncMock()
+    connection.fetchval = AsyncMock(side_effect=[0, "viewer"])
+    _attach_transaction_cm(connection)
+
+    payload = {
+        "users": ["alice"],
+        "name": "p1",
+        "permissions": {"type": "viewer"},
+    }
+    current_user = {"username": "admin_user", "role": "administrator"}
+
+    response = asyncio.run(
+        create_policy_endpoint.create_policy(
+            payload=payload,
+            current_user=current_user,
+            pgpool=_mock_pgpool(connection),
+        )
+    )
+
+    sql_calls = [c.args[0] for c in connection.execute.await_args_list]
+    assert any('SET ROLE "admin_user";' in sql for sql in sql_calls)
+    assert any("RESET ROLE;" in sql for sql in sql_calls)
+    assert response.status_code == 201
+
+
+def test_update_policy_sets_and_resets_role_for_admin():
+    connection = AsyncMock()
+    connection.execute = AsyncMock()
+    connection.fetchrow = AsyncMock(
+        return_value={"tablename": "Datastream", "cmd": "SELECT"}
+    )
+    _attach_transaction_cm(connection)
+
+    payload = {"policy": "true"}
+    current_user = {"username": "admin_user", "role": "administrator"}
+
+    response = asyncio.run(
+        update_policy_endpoint.update_policy(
+            policy="p1",
+            payload=payload,
+            current_user=current_user,
+            pgpool=_mock_pgpool(connection),
+        )
+    )
+
+    sql_calls = [c.args[0] for c in connection.execute.await_args_list]
+    assert any('SET ROLE "admin_user";' in sql for sql in sql_calls)
+    assert any("RESET ROLE;" in sql for sql in sql_calls)
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
This PR strengthens RBAC enforcement for policy management by introducing explicit database role context handling in policy create and update endpoints.

---

## What Changed
- Added `SET ROLE` for authenticated administrator requests in:
  - `policy.py` (create endpoint)
  - `policy.py` (update endpoint)

- Ensured `RESET ROLE` is always executed using `finally` blocks to prevent leaked database role context:
  - `policy.py` (create endpoint)
  - `policy.py` (update endpoint)

- Added regression tests to validate role switching behavior:
  - `test_policy_role_switch.py`

---

## Why
Application-level admin checks alone are not sufficient for robust security.  
Explicit database role switching provides **defense-in-depth** and minimizes the impact of potential future authentication or authorization regressions.

---
### Before vs After

<img width="500" height="800" alt="image" src="https://github.com/user-attachments/assets/dec63870-c42a-40ba-b452-ef61527bd015" />


---

## Testing
Added the following tests:
- `test_create_policy_sets_and_resets_role_for_admin`
- `test_update_policy_sets_and_resets_role_for_admin`

Test file:
- `test_policy_role_switch.py`

---

## Risk
Low.  
Changes are limited to role context handling around SQL execution in policy endpoints and are covered by regression tests.

---

## Notes
- Ensures no role leakage across requests.
- Aligns with secure database access best practices.

---

fixes #113 