### PR TITLE
fix(auth): block refresh for revoked tokens

### DIFF
--- a/api/app/v1/endpoints/create/login.py
+++ b/api/app/v1/endpoints/create/login.py
@@ -72,6 +72,13 @@ async def refresh_token(authorization=Header()):
         )
     token = authorization[len(prefix) :].strip()
 
+    if REDIS and redis.get(token) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has been revoked",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     try:
         payload = decode_token(token)
     except Exception:


### PR DESCRIPTION
### description 
refresh endpoint decodes token& issues a new token without checking revocation state in redis.
 a revoked/logged-out token can still be refreshed

the **expected behaviour** is that `POST /Refresh` should deny revoked tokens with `401` and should not mint a new token.
but currently i noticed that the revoked tokens  can still get hold of fresh access tokens


the fix that i am implementing is that we should enable redis revocation state being checked before issuing tokens
also return 401  for the revoked tokens and basically skip new token creation