### PR TITLE
Fix RBAC bypass for Users/Policies in anonymous viewer mode

### DIFF
--- a/api/app/v1/endpoints/read/policy.py
+++ b/api/app/v1/endpoints/read/policy.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import ujson
-from app import ANONYMOUS_VIEWER, AUTHORIZATION
+from app import AUTHORIZATION
 from app.db.asyncpg_db import get_pool
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Depends, Header, Query, status
@@ -24,7 +24,7 @@ from .read import set_role
 v1 = APIRouter()
 user = Header(default=None, include_in_schema=False)
 
-if AUTHORIZATION and not ANONYMOUS_VIEWER:
+if AUTHORIZATION:
     from app.oauth import get_current_user
 
     user = Depends(get_current_user)

--- a/api/app/v1/endpoints/read/user.py
+++ b/api/app/v1/endpoints/read/user.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import ujson
-from app import ANONYMOUS_VIEWER, AUTHORIZATION
+from app import AUTHORIZATION
 from app.db.asyncpg_db import get_pool
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Depends, Header, status
@@ -25,7 +25,7 @@ v1 = APIRouter()
 
 user = Header(default=None, include_in_schema=False)
 
-if AUTHORIZATION and not ANONYMOUS_VIEWER:
+if AUTHORIZATION:
     from app.oauth import get_current_user
 
     user = Depends(get_current_user)


### PR DESCRIPTION

## Problem
With `AUTHORIZATION=1` and `ANONYMOUS_VIEWER=1`, `GET /Users` and `GET /Policies` could be reached without authentication.
These endpoints expose authorization metadata and should remain admin-only.

## What Changed
Require auth dependency whenever `AUTHORIZATION` is enabled in:
* `user.py:28`
* `policy.py:27`

## Before vs After

<img width="585" height="1031" alt="image" src="https://github.com/user-attachments/assets/3a9b5982-7bf0-4def-80b3-0025b8a96810" />


## Why This Is Safe
* Change is narrow and limited to Users/Policies read endpoints.
* Public entity read endpoints are unchanged.
* Existing admin role checks remain in place.

## Security Impact
Prevents unauthorized disclosure of:
* User metadata
* Policy metadata

## Checklist
- [x] Minimal code changes
- [x] No API contract changes for public data endpoints

---
fixes #115 