### PR TITLE
fix(rbac): return 403 for insufficient privileges on create endpoints

### DIFF
--- a/api/app/v1/endpoints/create/bulk_observation.py
+++ b/api/app/v1/endpoints/create/bulk_observation.py
@@ -96,9 +96,9 @@ async def bulk_observations(
                     )
                 except InsufficientPrivilegeError:
                     return JSONResponse(
-                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        status_code=status.HTTP_403_FORBIDDEN,
                         content={
-                            "code": 401,
+                            "code": 403,
                             "type": "error",
                             "message": "Insufficient privileges.",
                         },
@@ -157,9 +157,9 @@ async def bulk_observations(
                         )
                     except InsufficientPrivilegeError:
                         return JSONResponse(
-                            status_code=status.HTTP_401_UNAUTHORIZED,
+                            status_code=status.HTTP_403_FORBIDDEN,
                             content={
-                                "code": 401,
+                                "code": 403,
                                 "type": "error",
                                 "message": "Insufficient privileges.",
                             },

--- a/api/app/v1/endpoints/create/data_array_observation.py
+++ b/api/app/v1/endpoints/create/data_array_observation.py
@@ -121,9 +121,9 @@ async def data_array_observation(
                     )
                 except InsufficientPrivilegeError:
                     return JSONResponse(
-                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        status_code=status.HTTP_403_FORBIDDEN,
                         content={
-                            "code": 401,
+                            "code": 403,
                             "type": "error",
                             "message": "Insufficient privileges.",
                         },
@@ -196,9 +196,9 @@ async def data_array_observation(
                             response_urls.append(observation_selfLink)
                         except InsufficientPrivilegeError:
                             return JSONResponse(
-                                status_code=status.HTTP_401_UNAUTHORIZED,
+                                status_code=status.HTTP_403_FORBIDDEN,
                                 content={
-                                    "code": 401,
+                                    "code": 403,
                                     "type": "error",
                                     "message": "Insufficient privileges.",
                                 },
@@ -214,9 +214,9 @@ async def data_array_observation(
 
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/datastream.py
+++ b/api/app/v1/endpoints/create/datastream.py
@@ -115,9 +115,9 @@ async def create_datastream(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -200,9 +200,9 @@ async def create_datastream_for_thing(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -288,9 +288,9 @@ async def create_datastream_for_sensor(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -376,9 +376,9 @@ async def create_datastream_for_observed_property(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/feature_of_interest.py
+++ b/api/app/v1/endpoints/create/feature_of_interest.py
@@ -102,9 +102,9 @@ async def create_feature_of_interest(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/historical_location.py
+++ b/api/app/v1/endpoints/create/historical_location.py
@@ -92,9 +92,9 @@ async def create_historical_location(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -169,9 +169,9 @@ async def create_historical_location_for_thing(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/location.py
+++ b/api/app/v1/endpoints/create/location.py
@@ -102,9 +102,9 @@ async def create_location(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -174,9 +174,9 @@ async def create_location_for_thing(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/network.py
+++ b/api/app/v1/endpoints/create/network.py
@@ -92,9 +92,9 @@ async def create_network(
         )
     except InsufficientPrivilegeError as e:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/observation.py
+++ b/api/app/v1/endpoints/create/observation.py
@@ -102,9 +102,9 @@ async def create_observation(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -191,9 +191,9 @@ async def create_observation_for_datastream(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -272,9 +272,9 @@ async def create_observation_for_feature_of_interest(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/observed_property.py
+++ b/api/app/v1/endpoints/create/observed_property.py
@@ -100,9 +100,9 @@ async def create_observed_property(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/policy.py
+++ b/api/app/v1/endpoints/create/policy.py
@@ -147,7 +147,7 @@ async def create_policy(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={"message": "Insufficient privileges."},
         )
     except Exception as e:

--- a/api/app/v1/endpoints/create/sensor.py
+++ b/api/app/v1/endpoints/create/sensor.py
@@ -102,9 +102,9 @@ async def create_sensor(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/thing.py
+++ b/api/app/v1/endpoints/create/thing.py
@@ -100,9 +100,9 @@ async def create_thing(
         )
     except InsufficientPrivilegeError as e:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },
@@ -173,9 +173,9 @@ async def create_thing_for_location(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={
-                "code": 401,
+                "code": 403,
                 "type": "error",
                 "message": "Insufficient privileges.",
             },

--- a/api/app/v1/endpoints/create/user.py
+++ b/api/app/v1/endpoints/create/user.py
@@ -162,7 +162,7 @@ async def create_user(
         )
     except InsufficientPrivilegeError:
         return JSONResponse(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             content={"message": "Insufficient privileges."},
         )
     except Exception as e:


### PR DESCRIPTION
## Summary

This PR updates RBAC authorization failure handling in create endpoints to return `403 Forbidden` instead of `401 Unauthorized` when `InsufficientPrivilegeError` is raised.

---

## What Changed

RBAC denial paths across create endpoints now correctly return `HTTP 403` for authorization failures.

### Key Updates

* Replaced `401 Unauthorized` with `403 Forbidden` in RBAC denial handlers.
* Updated response payload `code` values from `401` to `403` where applicable.
* Ensured no changes to authentication or login-related flows.

---

## Files Updated

* `api/app/v1/endpoints/create/sensor.py`
* `api/app/v1/endpoints/create/observed_property.py`
* `api/app/v1/endpoints/create/datastream.py`
* `api/app/v1/endpoints/create/feature_of_interest.py`
* `api/app/v1/endpoints/create/location.py`
* `api/app/v1/endpoints/create/thing.py`
* `api/app/v1/endpoints/create/observation.py`
* `api/app/v1/endpoints/create/historical_location.py`
* `api/app/v1/endpoints/create/network.py`
* `api/app/v1/endpoints/create/policy.py`
* `api/app/v1/endpoints/create/user.py`
* `api/app/v1/endpoints/create/bulk_observation.py`
* `api/app/v1/endpoints/create/data_array_observation.py`

---

## Why This Change

`InsufficientPrivilegeError` represents an **authorization failure**, not an authentication failure.

## Behavior Change Diagram (Before vs After)

```mermaid
flowchart TD

A[Client Request: POST /Create Endpoint] --> B[User Authenticated?]

B -->|No| C[Return 401 Unauthorized]

B -->|Yes| D[Check RBAC Permissions]

D -->|Has Permission| E[Resource Created Successfully]

%% BEFORE
D -->|Insufficient Privileges| F[Before: Return 401 ❌]
F --> G[Incorrect: Treated as Authentication Failure]

%% AFTER
D -->|Insufficient Privileges| H[After: Return 403 ✅]
H --> I[Correct: Authorization Failure]
```


According to HTTP semantics:

* `401 Unauthorized` → Authentication failure (missing/invalid credentials)
* `403 Forbidden` → Authorization failure (insufficient permissions)

Returning `401` in RBAC denial paths leads to incorrect API behavior and can confuse clients and middleware relying on proper status codes.

---

## Behavior After Change

* RBAC denial paths now return `status.HTTP_403_FORBIDDEN`.
* Error payloads are aligned with `403` semantics.
* Authentication flows remain unchanged and continue returning `401` where appropriate.

---

## Validation

* Static checks: No errors detected in updated create endpoint files.
* Runtime tests: Not executed in this environment due to absence of `pytest`.

---

## Impact

* Aligns API behavior with HTTP standards.
* Improves consistency across protected endpoints.
* Prevents misinterpretation of authorization failures by clients and API gateways.

--- 
Fixes #122 
