### PR TITLE
feat(thing): expose observedArea on Thing for STAC and DCAT-AP spatial extent

### DIFF
--- a/api/app/models/thing.py
+++ b/api/app/models/thing.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from app.db.sqlalchemy_db import SCHEMA_NAME, Base
+from geoalchemy2 import Geometry
 from sqlalchemy.dialects.postgresql.json import JSON
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.schema import Column, ForeignKey
@@ -36,6 +37,7 @@ class Thing(Base):
     name = Column(String(255), nullable=False)
     description = Column(Text, nullable=False)
     properties = Column(JSON)
+    observed_area = Column("observedArea", Geometry)
     commit_id = Column(Integer, ForeignKey(f"{SCHEMA_NAME}.Commit.id"))
     location = relationship(
         "Location", secondary=Thing_Location, back_populates="thing"

--- a/api/app/sta2rest/sta2rest.py
+++ b/api/app/sta2rest/sta2rest.py
@@ -128,6 +128,7 @@ class STA2REST:
             "name",
             "description",
             "properties",
+            "observed_area",
         ],
         "ThingTravelTime": [
             "id",
@@ -138,6 +139,7 @@ class STA2REST:
             "name",
             "description",
             "properties",
+            "observed_area",
             "system_time_validity",
         ],
         "HistoricalLocation": [

--- a/database/istsos_schema.sql
+++ b/database/istsos_schema.sql
@@ -72,6 +72,17 @@ CREATE OR REPLACE FUNCTION "Datastreams@iot.navigationLink"(sensorthings."Thing"
     SELECT '/Things(' || $1.id || ')/Datastreams';
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION "observedArea"(sensorthings."Thing") RETURNS geometry AS $$
+BEGIN
+    RETURN (
+        SELECT ST_ConvexHull(ST_Collect(d."observedArea"))
+        FROM sensorthings."Datastream" d
+        WHERE d."thing_id" = $1.id
+          AND d."observedArea" IS NOT NULL
+    );
+END;
+$$ LANGUAGE plpgsql STABLE;
+
 CREATE TABLE IF NOT EXISTS sensorthings."Thing_Location" (
     "thing_id" BIGINT NOT NULL REFERENCES sensorthings."Thing"(id) ON DELETE CASCADE,
     "location_id" BIGINT NOT NULL REFERENCES sensorthings."Location"(id) ON DELETE CASCADE,


### PR DESCRIPTION
## What this does

Adds `observedArea` as a computed derived field on the `Thing` entity, returning the aggregated spatial footprint of each Thing in a single `GET /Things` response.

```json
{
  "@iot.id": 1,
  "name": "thing_name_1",
  "observedArea": {
    "type": "Polygon",
    "coordinates": [[[97.72, 25.12], [-165.38, 37.54], "..."]]
  }
}
```

## Spec note

`observedArea` is defined by OGC STA 1.1 on `Datastream`, not on `Thing`. Noticing the already made extensions from the standard entity Thing by adding `Commit`, this PR adds `observedArea` as a deliberate extension at the Thing level, consistent with istSOS4's existing pattern.

## Why this matters

In the STA to DCAT-AP 3.0 mapping, `Thing` is best modelled as a `dcat:DatasetSeries` a device-level grouping container for all its Datastreams. Connectors and harvesters that build a device-level catalog index need the spatial footprint of each Thing without having to expand into its Datastreams.

Without this field, that requires N requests:

```
GET /Things
GET /Things(1)/Datastreams   # to get observedArea
GET /Things(2)/Datastreams   # ...
GET /Things(N)/Datastreams   # ...
```

With this field, a single `GET /Things` gives the full device index including spatial extent in one call. This is paired with the `phenomenonTime` PR which does the same for temporal extent, together enabling complete `dcat:DatasetSeries` metadata from single request.

> Note: per the DCAT-AP mapping spec, `dct:spatial` on `dcat:Dataset` draws from
> `Datastream.observedArea` directly. This field targets the `dcat:DatasetSeries`
> (Thing) level, not the Dataset (Datastream) level.

## How it works

The PostgreSQL function `observedArea(sensorthings."Thing")` already existed in the schema. It computes `ST_ConvexHull(ST_Collect(...))` across all Datastreams belonging to the Thing, returning `NULL` if no Datastreams have geometry yet. This PR wires it up to the API layer with minimal changes:

- **`models/thing.py`** -> declares `observed_area = Column("observedArea", Geometry)` on the Thing ORM model so SQLAlchemy can select it
- **`sta2rest.py`** -> adds `observed_area` to Thing's `DEFAULT_SELECT` so it appears in all Thing responses without needing `$select`

The existing `get_select_attr` in `visitors.py` already handles `Geometry` columns by wrapping them in `ST_AsGeoJSON`, so the output is clean GeoJSON with no additional changes needed.

## Testing

```
GET /Things                              -> each Thing includes observedArea as GeoJSON or null
GET /Things(1)                           -> single Thing includes observedArea
GET /Things?$select=id,name,observedArea -> $select works correctly
```

<!-- screenshots -->
<img width="968" height="743" alt="Screenshot 2026-03-23 182446" src="https://github.com/user-attachments/assets/61557221-d360-4b66-9342-2b8cef2ac095" />


<img width="791" height="539" alt="Screenshot 2026-03-23 172229" src="https://github.com/user-attachments/assets/7331964c-6ec6-4646-a89d-3e7c75cbbed3" />