### PR TITLE
feat(thing): expose phenomenonTime on Thing for STAC and DCAT-AP temporal extent

### DIFF
--- a/api/app/models/thing.py
+++ b/api/app/models/thing.py
@@ -14,6 +14,7 @@
 
 from app.db.sqlalchemy_db import SCHEMA_NAME, Base
 from sqlalchemy.dialects.postgresql.json import JSON
+from sqlalchemy.dialects.postgresql.ranges import TSTZRANGE
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.schema import Column, ForeignKey
 from sqlalchemy.sql.sqltypes import Integer, String, Text
@@ -36,6 +37,7 @@ class Thing(Base):
     name = Column(String(255), nullable=False)
     description = Column(Text, nullable=False)
     properties = Column(JSON)
+    phenomenon_time = Column("phenomenonTime", TSTZRANGE)
     commit_id = Column(Integer, ForeignKey(f"{SCHEMA_NAME}.Commit.id"))
     location = relationship(
         "Location", secondary=Thing_Location, back_populates="thing"

--- a/api/app/sta2rest/sta2rest.py
+++ b/api/app/sta2rest/sta2rest.py
@@ -128,6 +128,7 @@ class STA2REST:
             "name",
             "description",
             "properties",
+            "phenomenon_time",
         ],
         "ThingTravelTime": [
             "id",
@@ -138,6 +139,7 @@ class STA2REST:
             "name",
             "description",
             "properties",
+            "phenomenon_time",
             "system_time_validity",
         ],
         "HistoricalLocation": [

--- a/database/istsos_schema.sql
+++ b/database/istsos_schema.sql
@@ -72,6 +72,21 @@ CREATE OR REPLACE FUNCTION "Datastreams@iot.navigationLink"(sensorthings."Thing"
     SELECT '/Things(' || $1.id || ')/Datastreams';
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION "phenomenonTime"(sensorthings."Thing") RETURNS tstzrange AS $$
+BEGIN
+    RETURN (
+        SELECT tstzrange(
+            min(lower(d."phenomenonTime")),
+            max(upper(d."phenomenonTime")),
+            '[]'
+        )
+        FROM sensorthings."Datastream" d
+        WHERE d."thing_id" = $1.id
+          AND d."phenomenonTime" IS NOT NULL
+    );
+END;
+$$ LANGUAGE plpgsql STABLE;
+
 CREATE TABLE IF NOT EXISTS sensorthings."Thing_Location" (
     "thing_id" BIGINT NOT NULL REFERENCES sensorthings."Thing"(id) ON DELETE CASCADE,
     "location_id" BIGINT NOT NULL REFERENCES sensorthings."Location"(id) ON DELETE CASCADE,


### PR DESCRIPTION
## What this does

Adds `phenomenonTime` as a computed derived field on the `Thing` entity, returning the aggregated temporal extent across all of a Thing's Datastreams in a single `GET /Things` response.

```json
{
  "@iot.id": 1,
  "name": "thing_name_1",
  "observedArea": { "type": "Polygon", "coordinates": ["..."] },
  "phenomenonTime": "2020-01-01T11:05:00Z/2020-01-08T11:00:00Z"
}
```

## Spec note

`phenomenonTime` is defined by OGC STA 1.1 on `Datastream` and `Observation`, not on `Thing`. This PR adds it as a deliberate extension at the Thing level, consistent with istSOS4's existing pattern of extending the standard entity model (see `Commit` ntity).

## Why this matters

In the STA to DCAT-AP 3.0 mapping, `Thing` is best modelled as a `dcat:DatasetSeries` a device-level grouping container for all its Datastreams. Connectors and harvesters that build a device-level catalog index need the temporal extent of each Thing without having to expand into its Datastreams.

Without this field, that requires N+1 requests:

```
GET /Things
GET /Things(1)/Datastreams   # to compute phenomenonTime union
GET /Things(2)/Datastreams   # ...
GET /Things(N)/Datastreams   # ...
```

With this field, a single `GET /Things` gives the full device index including temporal extent in one call. Together with PR #124 (`observedArea` on Thing), a connector can now retrieve complete spatial and temporal metadata for all Things in a single request with no follow-up calls.

> Note: per the DCAT-AP mapping spec, `dct:temporal` on `dcat:Dataset` draws from
> `Datastream.phenomenonTime` directly. This field targets the `dcat:DatasetSeries`
> (Thing) level, not the Dataset (Datastream) level.

## How it works

Unlike `observedArea`, no PostgreSQL function existed for `phenomenonTime` on `Thing`. This PR adds it from scratch:

- **`istsos_schema.sql`** -> new `phenomenonTime(sensorthings."Thing")` function that computes `tstzrange(min(lower(d."phenomenonTime")), max(upper(d."phenomenonTime")), '[]')` across all Datastreams of the Thing, returning `NULL` if none have a time range yet
- **`models/thing.py`** -> declares `phenomenon_time = Column("phenomenonTime", TSTZRANGE)` on the Thing ORM model
- **`sta2rest.py`** -> adds `phenomenon_time` to Thing and ThingTravelTime `DEFAULT_SELECT`

The existing `get_select_attr` in `visitors.py` already handles `TSTZRANGE` columns by formatting them as ISO 8601 intervals (`start/end`), identical to how Datastream's
`phenomenonTime` is serialized. No additional changes needed.

## Testing

```
GET /Things                               -> each Thing includes phenomenonTime as ISO 8601 interval or null
GET /Things(1)                            -> single Thing includes phenomenonTime
GET /Things?$select=id,name,phenomenonTime -> $select works correctly
```

<!-- screenshots -->


<img width="757" height="655" alt="Screenshot 2026-03-23 190321" src="https://github.com/user-attachments/assets/37a38a8b-1d5b-4be6-9f0b-8894ff79eff9" />
<img width="746" height="447" alt="Screenshot 2026-03-23 190343" src="https://github.com/user-attachments/assets/e22bff51-03ad-4ab9-9b70-06e554c1d1ac" />