### PR TITLE
fix: reset User sequence after manual ID insertion

### DIFF
--- a/api/app/v1/endpoints/create/user.py
+++ b/api/app/v1/endpoints/create/user.py
@@ -15,7 +15,12 @@
 import json
 
 from app import HOSTNAME, POSTGRES_PORT_WRITE, SUBPATH, VERSION
-from app.utils.utils import pg_quote_ident, pg_quote_literal, validate_username
+from app.utils.utils import (
+    extract_iot_id,
+    pg_quote_ident,
+    pg_quote_literal,
+    validate_username,
+)
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
 from app.v1.endpoints.functions import insert_commit, set_role
@@ -98,6 +103,10 @@ async def create_user(
 
                 password = payload.pop("password", None)
 
+                if "@iot.id" in payload:
+                    payload["id"] = extract_iot_id(payload)
+                    payload.pop("@iot.id")
+
                 for key in list(payload.keys()):
                     if isinstance(payload[key], dict):
                         payload[key] = json.dumps(payload[key])
@@ -112,6 +121,11 @@ async def create_user(
                     RETURNING id, username, uri;
                 """
                 user = await connection.fetchrow(query, *payload.values())
+
+                if "id" in payload:
+                    await connection.execute(
+                        "SELECT setval(pg_get_serial_sequence('sensorthings.\"User\"', 'id'), (SELECT MAX(id) FROM sensorthings.\"User\"))"
+                    )
 
                 if not payload.get("uri"):
                     query = """


### PR DESCRIPTION
Issue #126 

## PR Summary

This PR addresses the **sequence desynchronization bug** specifically for the **User creation endpoint**.

---

### Changes

- Modified `api/app/v1/endpoints/create/user.py` to handle manual `@iot.id` provision.
- Integrated the `extract_iot_id()` helper to validate and extract IDs from the request payload.
- Added a `setval` call after successful insertion to synchronize the `User_id_seq` sequence with the maximum ID in the table.
- Ensures that subsequent auto-incremented user creations **do not collide** with manually inserted records.