### PR TITLE
fix(rbac): harden SET ROLE in CreateObservations

### DIFF
--- a/api/app/v1/endpoints/create/data_array_observation.py
+++ b/api/app/v1/endpoints/create/data_array_observation.py
@@ -30,6 +30,7 @@ from app.utils.utils import (
     handle_datetime_fields,
     handle_result_field,
 )
+from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from asyncpg.types import Range
 from fastapi import APIRouter, Body, Depends, Header, status
@@ -110,10 +111,7 @@ async def data_array_observation(
         async with pool.acquire() as conn:
             async with conn.transaction():
                 if current_user is not None:
-                    query = 'SET ROLE "{username}";'
-                    await conn.execute(
-                        query.format(username=current_user["username"])
-                    )
+                    await set_role(conn, current_user)
 
                 try:
                     commit_id = await set_commit(

--- a/api/app/v1/endpoints/functions.py
+++ b/api/app/v1/endpoints/functions.py
@@ -15,13 +15,13 @@
 import json
 
 from app import ST_AGGREGATE
+from app.utils.utils import pg_quote_ident
 
 
 async def set_role(connection, current_user):
     async with connection.transaction():
-        query = 'SET ROLE "{username}";'
         await connection.execute(
-            query.format(username=current_user["username"])
+            f"SET ROLE {pg_quote_ident(current_user['username'])};"
         )
 
 

--- a/api/tests/test_set_role_sql_safety.py
+++ b/api/tests/test_set_role_sql_safety.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+API_DIR = str(Path(__file__).resolve().parents[1])
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+os.environ.setdefault("POSTGRES_DB", "istsos")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+
+from app.v1.endpoints.functions import set_role  # noqa: E402
+
+
+async def test_set_role_quotes_postgres_identifier():
+    connection = AsyncMock()
+
+    @asynccontextmanager
+    async def transaction():
+        yield
+
+    connection.transaction = transaction
+
+    await set_role(connection, {"username": 'test"user'})
+
+    connection.execute.assert_awaited_once_with('SET ROLE "test""user";')


### PR DESCRIPTION
## Summary

This PR removes inline `SET ROLE` SQL construction from `POST /CreateObservations` and routes role switching through the shared helper.

It also hardens the shared `set_role(...)` helper by safely quoting PostgreSQL identifiers before execution.

## Changes

- replaced inline `SET ROLE "{username}"` formatting in `CreateObservations`
- updated shared `set_role(...)` helper to use safe identifier quoting
- added regression coverage for quoted usernames

## Why

Role switching should not build SQL using manual string formatting. Centralizing and hardening this behavior makes RBAC write paths safer and more consistent.

## Validation

- Added focused test: `api/tests/test_set_role_sql_safety.py`
- Syntax-checked changed Python files locally

## Notes

`pytest` was not available in this environment, so the new test was added but not executed here.

---
fixes #128 
