### PR TITLE
fix: always show @iot.nextLink even when @iot.count < 100

### DIFF
--- a/api/app/v1/endpoints/read/read.py
+++ b/api/app/v1/endpoints/read/read.py
@@ -274,6 +274,8 @@ async def asyncpg_stream_results(
                     next_link_json = (
                         f'"@iot.nextLink": "{next_link}",'
                         if next_link and not single_result
+                        else '"@iot.nextLink": null,'
+                        if not single_result
                         else ""
                     )
                     as_of = (


### PR DESCRIPTION
Continued in #131 which fixes `@iot.count` always being present.

## What this fixes
Collection responses like `GET /Things` were missing `@iot.nextLink` from the top-level envelope when there was no next page. The field was only included when a next page existed, and silently dropped otherwise.

This means a client had no way to distinguish between "there are no more pages" and "this field is not supported here".

## Spec note
OGC STA 1.1 defines the collection response envelope as:
```json
{
  "@iot.count": 8,
  "@iot.nextLink": "https://<server_url>/v1.0/Observations?$top=100&$skip=100",
  "value": [ ... ]
}
```
Both `@iot.nextLink` and `@iot.count` must always be present. A non-null `@iot.nextLink` signals the client to fetch the next page. A null value explicitly signals the current page is the last one. Omitting it entirely is not spec-compliant.

## What was inconsistent
Expanded sub-collections like `Datastreams` or `Locations` inside a Thing were already emitting `@iot.nextLink: null` correctly. Only the top-level collection response was skipping the field when null.

## The fix
In `read.py`, the `next_link_json` assignment previously used a condition that produced an empty string when there was no next page. This PR changes it to always emit `@iot.nextLink` in collection responses, either as a URL or as null.

## Testing
Screenshots attached showing before (field missing from top-level response) and after (field always present, null when on the last page).
<img width="684" height="286" alt="Screenshot 2026-03-25 230430" src="https://github.com/user-attachments/assets/b74df2f3-5447-4a23-9f01-b723a28176c9" />
<img width="641" height="308" alt="Screenshot 2026-03-25 230217" src="https://github.com/user-attachments/assets/49ca81ea-6c09-42b6-8b3b-8bfee7d196cf" />