### PR TITLE
fix: always emit @iot.count in top-level collection responses

### DIFF
--- a/api/app/sta2rest/visitors.py
+++ b/api/app/sta2rest/visitors.py
@@ -788,7 +788,7 @@ class NodeVisitor(Visitor):
         is_count = self.visit_CountNode(node.count) if node.count else False
 
         count_queries = []
-        if is_count:
+        if not self.single_result:
             if COUNT_MODE in {"LIMIT_ESTIMATE", "ESTIMATE_LIMIT"}:
                 estimate_query_str = str(
                     query_estimate_count.compile(

--- a/api/app/v1/endpoints/read/read.py
+++ b/api/app/v1/endpoints/read/read.py
@@ -191,7 +191,7 @@ async def asyncpg_stream_results(
                     current_user = {"username": "guest"}
                     await set_role(connection, current_user)
 
-            if is_count:
+            if not single_result and count_queries:
                 if COUNT_MODE == "LIMIT_ESTIMATE":
                     query_count = await connection.fetchval(count_queries[0])
                     if query_count == COUNT_ESTIMATE_THRESHOLD:
@@ -210,10 +210,12 @@ async def asyncpg_stream_results(
                         )
                 else:
                     query_count = await connection.fetchval(count_queries[0])
+            else:
+                query_count = None
 
             iot_count = (
                 '"@iot.count": ' + str(query_count) + ","
-                if is_count and not single_result
+                if query_count is not None and not single_result
                 else ""
             )
             await connection.execute(f"DECLARE my_cursor CURSOR FOR {query}")


### PR DESCRIPTION
Follows up on #130 which fixed `@iot.nextLink` always being present.

## What this fixes
Collection responses like `GET /Things` were missing `@iot.count` from the top-level envelope entirely. The field was only included when the client explicitly passed `$count=true`, and silently dropped otherwise.

## Spec note
OGC STA 1.1 defines the collection response envelope as:
```json
{
  "@iot.count": 8,
  "@iot.nextLink": "...",
  "value": [ ... ]
}
```
`@iot.count` must always be present in collection responses, reflecting the total number of matching entities. Requiring clients to opt in with `$count=true` is not spec-compliant.

## What was broken
The count SQL was already being built and correctly filtered throughout `visit_QueryNode` in `visitors.py`, it just was not being compiled into `count_queries` unless `$count=true` was in the URL. `read.py` was therefore always receiving an empty list and skipping count execution entirely for normal requests.

## The fix
**`visitors.py`** - the `count_queries` population block was gated on `if is_count:`. Changed to `if not self.single_result:` so count SQL is always compiled for collection endpoints. Single-entity requests like `Observations(34)` are correctly excluded.

**`read.py`** - the count execution block was also gated on `if is_count:`. Changed to `if not single_result and count_queries:` so the count query is always executed and `@iot.count` always appears in the response envelope for collections.

## Testing
Before: `GET /Things` -> no `@iot.count` field in response
After: `GET /Things` -> `"@iot.count": 5` always present

<img width="781" height="437" alt="Screenshot 2026-03-25 232948" src="https://github.com/user-attachments/assets/ede73b1b-484b-4f85-9f45-27376af424a2" />

<img width="706" height="451" alt="Screenshot 2026-03-25 233642" src="https://github.com/user-attachments/assets/2f5c6ced-c976-44c1-abdd-624e906003f3" />