### PR TITLE
Fix JSON content-type validation in create endpoints

### DIFF
--- a/api/app/utils/utils.py
+++ b/api/app/utils/utils.py
@@ -23,6 +23,25 @@ from dateutil import parser
 _USERNAME_RE = re.compile(r"^[a-zA-Z0-9_]{3,63}$")
 
 
+def require_json_content_type(request):
+    """
+    Ensure the request content type is JSON, allowing standard parameters
+    like ``charset=utf-8``.
+
+    Args:
+        request (Request): Incoming FastAPI request.
+
+    Raises:
+        Exception: If the request does not declare a JSON content type.
+    """
+
+    content_type = request.headers.get("content-type", "")
+    media_type = content_type.split(";", 1)[0].strip().lower()
+
+    if media_type != "application/json":
+        raise Exception("Only content-type application/json is supported.")
+
+
 def safe_parse_datetime(value):
     """
     Safely parse a datetime string using dateutil.parser.

--- a/api/app/v1/endpoints/create/datastream.py
+++ b/api/app/v1/endpoints/create/datastream.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -84,11 +84,7 @@ async def create_datastream(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
 
@@ -164,11 +160,7 @@ async def create_datastream_for_thing(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not thing_id:
             raise Exception("Thing ID is required.")
@@ -249,11 +241,7 @@ async def create_datastream_for_sensor(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not sensor_id:
             raise Exception("Sensor ID is required.")
@@ -337,11 +325,7 @@ async def create_datastream_for_observed_property(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not observed_property_id:
             raise Exception("Observed Property ID is required.")

--- a/api/app/v1/endpoints/create/feature_of_interest.py
+++ b/api/app/v1/endpoints/create/feature_of_interest.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys, validate_required_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -70,11 +70,7 @@ async def create_feature_of_interest(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
         validate_required_keys(payload, REQUIRED_KEYS)

--- a/api/app/v1/endpoints/create/historical_location.py
+++ b/api/app/v1/endpoints/create/historical_location.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -60,11 +60,7 @@ async def create_historical_location(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
 
@@ -132,11 +128,7 @@ async def create_historical_location_for_thing(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not thing_id:
             raise Exception("Thing ID is required.")

--- a/api/app/v1/endpoints/create/location.py
+++ b/api/app/v1/endpoints/create/location.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys, validate_required_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -70,11 +70,7 @@ async def create_location(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
         validate_required_keys(payload, REQUIRED_KEYS)
@@ -137,11 +133,7 @@ async def create_location_for_thing(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not thing_id:
             raise Exception("Thing ID not provided")

--- a/api/app/v1/endpoints/create/network.py
+++ b/api/app/v1/endpoints/create/network.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys, validate_required_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -60,11 +60,7 @@ async def create_network(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
         validate_required_keys(payload, REQUIRED_KEYS)

--- a/api/app/v1/endpoints/create/observation.py
+++ b/api/app/v1/endpoints/create/observation.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import validate_payload_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError, UniqueViolationError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -71,11 +71,7 @@ async def create_observation(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
 
@@ -154,11 +150,7 @@ async def create_observation_for_datastream(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not datastream_id:
             raise Exception("Datastream ID not provided")
@@ -235,11 +227,7 @@ async def create_observation_for_feature_of_interest(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not feature_of_interest_id:
             raise Exception("FeatureOfInterest ID not provided")

--- a/api/app/v1/endpoints/create/observed_property.py
+++ b/api/app/v1/endpoints/create/observed_property.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys, validate_required_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -68,11 +68,7 @@ async def create_observed_property(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
         validate_required_keys(payload, REQUIRED_KEYS)

--- a/api/app/v1/endpoints/create/sensor.py
+++ b/api/app/v1/endpoints/create/sensor.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys, validate_required_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -70,11 +70,7 @@ async def create_sensor(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
         validate_required_keys(payload, REQUIRED_KEYS)

--- a/api/app/v1/endpoints/create/thing.py
+++ b/api/app/v1/endpoints/create/thing.py
@@ -14,7 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
-from app.utils.utils import validate_payload_keys, validate_required_keys
+from app.utils.utils import validate_payload_keys, validate_required_keys, require_json_content_type
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, Header, Request, status
@@ -68,11 +68,7 @@ async def create_thing(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         validate_payload_keys(payload, ALLOWED_KEYS)
         validate_required_keys(payload, REQUIRED_KEYS)
@@ -135,11 +131,7 @@ async def create_thing_for_location(
     pool=Depends(get_pool_w) if POSTGRES_PORT_WRITE else Depends(get_pool),
 ):
     try:
-        if (
-            not "content-type" in request.headers
-            or request.headers["content-type"] != "application/json"
-        ):
-            raise Exception("Only content-type application/json is supported.")
+        require_json_content_type(request)
 
         if not location_id:
             raise Exception("No location ID provided")


### PR DESCRIPTION
## Summary

This PR fixes JSON `Content-Type` validation in create endpoints.

Previously, several create routes only accepted the exact header value:

`application/json`

That caused valid requests like:

`application/json; charset=utf-8`

to be rejected with `400 Bad Request`.

## What Changed

- Added a shared helper in `api/app/utils/utils.py` to validate JSON content types safely
- Replaced strict header string comparisons in create endpoints with the shared helper
- Kept rejection behavior for non-JSON content types unchanged

## Why

Many normal HTTP clients send JSON requests with parameters such as `charset=utf-8`.
Those requests are still valid JSON and should not fail.

## Affected Endpoints

- `POST /Sensors`
- `POST /Datastreams`
- `POST /Locations`
- `POST /Things`
- `POST /Observations`
- `POST /ObservedProperties`
- `POST /FeaturesOfInterest`
- `POST /HistoricalLocations`
- `POST /Networks`

## Example

Previously rejected:

```http
Content-Type: application/json; charset=utf-8
Now accepted.
```
## Before v After
<img width="757" height="478" alt="image" src="https://github.com/user-attachments/assets/e772bf07-a6e2-4a15-9891-78f508822c08" />


## Verification
- Confirmed the old exact-match checks were replaced in the affected create endpoints
- Ran:
bash

python3 -m compileall api/app/utils/utils.py api/app/v1/endpoints/create
Issue

## Fixes JSON content-type validation bug in create endpoints.
Closes #132 