### PR TITLE
fix(rbac): harden policy DDL SQL and fix multi-user custom policy tar…

### DIFF
--- a/api/app/v1/endpoints/create/policy.py
+++ b/api/app/v1/endpoints/create/policy.py
@@ -15,7 +15,7 @@
 from app import POSTGRES_PORT_WRITE
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
-from app.v1.endpoints.functions import set_role
+from app.utils.utils import pg_quote_ident
 from asyncpg.exceptions import DuplicateObjectError, InsufficientPrivilegeError
 from fastapi import APIRouter, Body, Depends, status
 from fastapi.responses import JSONResponse, Response
@@ -168,34 +168,68 @@ async def create_policies(connection, users, policies, name):
         "observation": "Observation",
         "featuresofinterest": "FeaturesOfInterest",
     }
-    users = ", ".join(users)
-    for table, operations in policies.items():
-        table = table_mapping.get(table)
+    if not users:
+        raise Exception("At least one user is required to create a policy.")
+
+    users_sql = ", ".join(pg_quote_ident(user) for user in users)
+
+    for table_key, operations in policies.items():
+        table = table_mapping.get(table_key)
+        if table is None:
+            raise Exception(f"Unsupported table '{table_key}' in policy.")
+
+        if not isinstance(operations, dict) or not operations:
+            raise Exception(
+                f"Invalid operations for table '{table_key}'."
+            )
 
         for operation, condition in operations.items():
-            if operation in ["select", "delete"]:
+            operation_lc = operation.lower()
+            if operation_lc not in [
+                "select",
+                "insert",
+                "update",
+                "delete",
+                "all",
+            ]:
+                raise Exception(
+                    f"Unsupported operation '{operation}' for table '{table_key}'."
+                )
+
+            if not isinstance(condition, str) or not condition.strip():
+                raise Exception(
+                    f"Invalid condition for '{table_key}.{operation}'."
+                )
+
+            policy_name = pg_quote_ident(
+                f"{name}_{table.lower()}_{operation_lc}"
+            )
+            table_name = pg_quote_ident(table)
+            operation_sql = operation_lc.upper()
+
+            if operation_lc in ["select", "delete"]:
                 query = f"""
-                    CREATE POLICY "{name}_{table.lower()}_{operation}"
-                    ON sensorthings."{table}"
-                    FOR {operation}
-                    TO "{users}"
+                    CREATE POLICY {policy_name}
+                    ON sensorthings.{table_name}
+                    FOR {operation_sql}
+                    TO {users_sql}
                     USING ({condition});
                 """
             else:
-                if operation == "insert":
+                if operation_lc == "insert":
                     query = f"""
-                        CREATE POLICY "{name}_{table.lower()}_{operation}"
-                        ON sensorthings."{table}"
-                        FOR {operation}
-                        TO "{users}"
+                        CREATE POLICY {policy_name}
+                        ON sensorthings.{table_name}
+                        FOR {operation_sql}
+                        TO {users_sql}
                         WITH CHECK ({condition});
                     """
                 else:
                     query = f"""
-                        CREATE POLICY "{name}_{table.lower()}_{operation}"
-                        ON sensorthings."{table}"
-                        FOR {operation}
-                        TO "{users}"
+                        CREATE POLICY {policy_name}
+                        ON sensorthings.{table_name}
+                        FOR {operation_sql}
+                        TO {users_sql}
                         USING ({condition})
                         WITH CHECK ({condition});
                     """

--- a/api/app/v1/endpoints/delete/policy.py
+++ b/api/app/v1/endpoints/delete/policy.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.utils.utils import pg_quote_ident
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError, UndefinedObjectError
 from fastapi import APIRouter, Depends, Header, Query, status
@@ -61,8 +62,9 @@ async def delete_policy(
                 if tablename is None:
                     raise UndefinedObjectError()
 
-                query = 'DROP POLICY {} ON sensorthings."{}";'.format(
-                    policy, tablename
+                query = (
+                    f"DROP POLICY {pg_quote_ident(policy)} "
+                    f"ON sensorthings.{pg_quote_ident(tablename)};"
                 )
                 await connection.execute(query)
 

--- a/api/app/v1/endpoints/update/policy.py
+++ b/api/app/v1/endpoints/update/policy.py
@@ -15,7 +15,7 @@
 from app import POSTGRES_PORT_WRITE
 from app.db.asyncpg_db import get_pool, get_pool_w
 from app.oauth import get_current_user
-from app.utils.utils import validate_payload_keys
+from app.utils.utils import pg_quote_ident, validate_payload_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError, UndefinedObjectError
 from fastapi import APIRouter, Body, Depends, Query, status
@@ -77,29 +77,26 @@ async def update_policy(
                     tablename, cmd = row["tablename"], row["cmd"]
 
                 if payload.get("policy") is not None:
+                    condition = payload["policy"]
+                    if not isinstance(condition, str) or not condition.strip():
+                        raise Exception("Policy expression must be a non-empty string.")
+
+                    policy_ident = pg_quote_ident(policy)
+                    table_ident = pg_quote_ident(tablename)
+                    cmd_upper = (cmd or "").upper()
+
                     policy_sql = {
-                        "SELECT": 'ALTER POLICY {} ON sensorthings."{}" USING ({});'.format(
-                            policy, tablename, payload["policy"]
-                        ),
-                        "INSERT": 'ALTER POLICY {} ON sensorthings."{}" WITH CHECK ({});'.format(
-                            policy, tablename, payload["policy"]
-                        ),
-                        "UPDATE": 'ALTER POLICY {} ON sensorthings."{}" USING ({}) WITH CHECK ({});'.format(
-                            policy,
-                            tablename,
-                            payload["policy"],
-                            payload["policy"],
-                        ),
-                        "DELETE": 'ALTER POLICY {} ON sensorthings."{}" USING ({});'.format(
-                            policy, tablename, payload["policy"]
-                        ),
-                        "ALL": 'ALTER POLICY {} ON sensorthings."{}" USING ({}) WITH CHECK ({});'.format(
-                            policy,
-                            tablename,
-                            payload["policy"],
-                            payload["policy"],
-                        ),
-                    }.get(cmd)
+                        "SELECT": f"ALTER POLICY {policy_ident} ON sensorthings.{table_ident} USING ({condition});",
+                        "INSERT": f"ALTER POLICY {policy_ident} ON sensorthings.{table_ident} WITH CHECK ({condition});",
+                        "UPDATE": f"ALTER POLICY {policy_ident} ON sensorthings.{table_ident} USING ({condition}) WITH CHECK ({condition});",
+                        "DELETE": f"ALTER POLICY {policy_ident} ON sensorthings.{table_ident} USING ({condition});",
+                        "ALL": f"ALTER POLICY {policy_ident} ON sensorthings.{table_ident} USING ({condition}) WITH CHECK ({condition});",
+                    }.get(cmd_upper)
+
+                    if policy_sql is None:
+                        raise Exception(
+                            f"Unsupported policy command '{cmd}'."
+                        )
 
                     await connection.execute(policy_sql)
 


### PR DESCRIPTION
## Summary

This PR fixes multi-user custom policy creation and improves safety in policy DDL SQL across create, update, and delete operations.

## Problem

- Custom policies with multiple users failed due to incorrect role formatting:
- role "u1, u2" does not exist
- Additionally, policy and table identifiers in DDL queries were not consistently quoted.

## Changes
 

- Construct role targets correctly: TO "user1", "user2"
- Add safe quoting for policy and table identifiers
- Improve validation for custom policy inputs
- Harden update and delete policy queries

---
## Result

- Multi-user custom policies now work as expected
- Update and delete operations behave correctly
- No changes to the existing API contract

---

## Before / After
Before: HTTP 400 (role "u1, u2" does not exist)
After: HTTP 201 / 200 / 200

<img width="907" height="365" alt="image" src="https://github.com/user-attachments/assets/9447264a-9da0-4f64-a2c2-1e83e5d7e207" />

---

## Impact

Resolves a functional issue and aligns policy handling with existing SQL safety practices.

---
Solves  #135 