### PR TITLE
test(schema): add integration tests for schema versioning, history triggers, and traveltime views

### DIFF
--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -1,5 +1,25 @@
 """
-Test module for schema versioning
+Tests for istsos_schema_versioning.sql
+
+Sections:
+1. istsos_mutate_history() trigger
+   - INSERT / UPDATE / DELETE behavior
+   - skip-archiving logic
+   - edge cases (ID mutation, known bug)
+
+2. istsos_prevent_table_update()
+   - history table immutability (UPDATE / DELETE blocked)
+
+3. add_table_to_versioning()
+   - systemTimeValidity column presence
+
+4. systemTimeValidity constraints
+   - exclusion constraint prevents overlapping ranges
+
+5. traveltime view
+   - row visibility (live + history)
+   - @iot.selfLink correctness
+   - Observation result() dispatch
 
 Run with:
     pytest test/test_schema_versioning.py -v
@@ -17,8 +37,6 @@ ADMIN_DSN = "postgresql://postgres:15889@localhost:5432/postgres"
 TEST_DB = "istsos_versioning_test"
 
 
-# DB bootstrap helpers
-
 def _get_raw_conn(dsn=DSN):
     conn = psycopg2.connect(dsn)
     conn.autocommit = True
@@ -26,7 +44,7 @@ def _get_raw_conn(dsn=DSN):
 
 
 def _recreate_database():
-    # Step 1: terminate connections and drop the versioning test DB
+    """Drop and recreate the test database, cleaning up roles beforehand."""
     admin_conn = psycopg2.connect(ADMIN_DSN)
     admin_conn.autocommit = True
     with admin_conn.cursor() as cur:
@@ -38,10 +56,8 @@ def _recreate_database():
         cur.execute(f"DROP DATABASE IF EXISTS {TEST_DB}")
     admin_conn.close()
 
-    # Step 2: connect to each *other* database that may hold objects owned by
-    # the roles we want to drop, and run DROP OWNED BY there first.
-    # We discover all non-template databases dynamically so this stays robust
-    # when test_schema.py has already created istsos_test with owned objects.
+    # Drop owned objects for roles across all surviving databases so
+    # DROP ROLE doesn't fail on dependent objects.
     discover_conn = psycopg2.connect(ADMIN_DSN)
     discover_conn.autocommit = True
     with discover_conn.cursor() as cur:
@@ -67,9 +83,8 @@ def _recreate_database():
                     """)
             db_conn.close()
         except Exception:
-            pass  # DB may have been dropped mid-loop; skip silently
+            pass  # DB may have been dropped mid-iteration
 
-    # Step 3: now the roles have no dependents - safe to drop them
     admin_conn = psycopg2.connect(ADMIN_DSN)
     admin_conn.autocommit = True
     with admin_conn.cursor() as cur:
@@ -80,6 +95,7 @@ def _recreate_database():
 
 
 def _load_schema(conn):
+    """Execute the base schema SQL with versioning enabled."""
     sql = SCHEMA_PATH.read_text()
     with conn.cursor() as cur:
         cur.execute("SET custom.epsg = '4326'")
@@ -93,6 +109,7 @@ def _load_schema(conn):
 
 
 def _load_versioning(conn):
+    """Execute the versioning SQL on top of the base schema."""
     sql = VERSIONING_PATH.read_text()
     with conn.cursor() as cur:
         cur.execute("SET custom.epsg = '4326'")
@@ -104,12 +121,16 @@ def _load_versioning(conn):
 
 class TestSchemaVersioning:
     """
-    All tests share one schema+versioning load per session.
-    Each test rolls back its own data changes via the `rollback` fixture.
+    Integration tests for system-versioned SensorThings tables.
+
+    The schema and versioning SQL are loaded once per class. Each test runs
+    inside a transaction that is rolled back on teardown, so tests are
+    fully isolated without needing to recreate the database each time.
     """
 
     @pytest.fixture(autouse=True, scope="class")
     def schema(self):
+        """Load the schema once and yield a transactional connection."""
         _recreate_database()
         setup_conn = _get_raw_conn()
         _load_schema(setup_conn)
@@ -123,27 +144,42 @@ class TestSchemaVersioning:
 
     @pytest.fixture(autouse=True)
     def rollback(self, schema):
+        """Roll back all mutations after each test."""
         yield
         schema.rollback()
 
-    # Row insertion helpers
+    # Insertion helpers
 
     def _get_id(self, row):
         return row[0] if not isinstance(row, dict) else row["id"]
 
     def _insert_commit(self, cur, action="CREATE"):
-        """Insert a Commit row (required by versioning) and return its id."""
+        """
+        Insert a Commit row and return its id.
+
+        Required because versioning adds a NOT NULL commit_id FK to most tables.
+        """
         cur.execute(
             """
-            INSERT INTO sensorthings."Commit"
-                ("author", "message", "actionType")
+            INSERT INTO sensorthings."Commit" ("author", "message", "actionType")
             VALUES ('test-author', 'test commit', %s)
             RETURNING id
             """,
             (action,),
         )
         return self._get_id(cur.fetchone())
-    
+
+    def _insert_minimal_thing(self, cur, name="v-thing"):
+        commit_id = self._insert_commit(cur)
+        cur.execute(
+            """
+            INSERT INTO sensorthings."Thing" ("name", "description", "commit_id")
+            VALUES (%s, 'desc', %s) RETURNING id
+            """,
+            (name, commit_id),
+        )
+        return self._get_id(cur.fetchone())
+
     def _insert_minimal_location(self, cur, name="v-loc"):
         commit_id = self._insert_commit(cur)
         cur.execute(
@@ -157,18 +193,7 @@ class TestSchemaVersioning:
             (name, commit_id),
         )
         return self._get_id(cur.fetchone())
-    
-    def _insert_minimal_thing(self, cur, name="v-thing"):
-        commit_id = self._insert_commit(cur)
-        cur.execute(
-            """
-            INSERT INTO sensorthings."Thing" ("name", "description", "commit_id")
-            VALUES (%s, 'desc', %s) RETURNING id
-            """,
-            (name, commit_id),
-        )
-        return self._get_id(cur.fetchone())
-    
+
     def _insert_minimal_sensor(self, cur, name="v-sensor"):
         commit_id = self._insert_commit(cur)
         cur.execute(
@@ -181,21 +206,21 @@ class TestSchemaVersioning:
             (name, commit_id),
         )
         return self._get_id(cur.fetchone())
-    
+
     def _insert_minimal_observed_property(self, cur, name="v-op"):
         commit_id = self._insert_commit(cur)
         cur.execute(
             """
             INSERT INTO sensorthings."ObservedProperty"
                 ("name", "definition", "description", "commit_id")
-            VALUES (%s, 'http://def', 'desc', %s)
-            RETURNING id
+            VALUES (%s, 'http://def', 'desc', %s) RETURNING id
             """,
             (name, commit_id),
         )
         return self._get_id(cur.fetchone())
-    
+
     def _insert_minimal_datastream(self, cur, thing_id, sensor_id, op_id, name="v-ds"):
+        # Datastream.commit_id is nullable, so no commit needed here.
         cur.execute(
             """
             INSERT INTO sensorthings."Datastream"
@@ -209,8 +234,9 @@ class TestSchemaVersioning:
             (name, thing_id, sensor_id, op_id),
         )
         return self._get_id(cur.fetchone())
-    
+
     def _insert_minimal_foi(self, cur, name="v-foi"):
+        # FeaturesOfInterest.commit_id is nullable.
         cur.execute(
             """
             INSERT INTO sensorthings."FeaturesOfInterest"
@@ -224,6 +250,7 @@ class TestSchemaVersioning:
         return self._get_id(cur.fetchone())
 
     def _setup_ds_foi(self, cur, suffix="v"):
+        """Create the full dependency chain needed for Datastream/Observation tests."""
         thing_id = self._insert_minimal_thing(cur, f"t-{suffix}")
         sensor_id = self._insert_minimal_sensor(cur, f"s-{suffix}")
         op_id = self._insert_minimal_observed_property(cur, f"op-{suffix}")
@@ -231,13 +258,10 @@ class TestSchemaVersioning:
         foi_id = self._insert_minimal_foi(cur, f"foi-{suffix}")
         return ds_id, foi_id, thing_id
 
-    # Tests start
-    
+    # istsos_mutate_history() - INSERT behavior
+
     def test_insert_sets_system_time_validity_start(self, schema):
-        """
-        After INSERT the live row must have systemTimeValidity =
-        [some finite lower bound, infinity).
-        """
+        """INSERT must set a finite lower bound on systemTimeValidity."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "stv-insert")
             cur.execute(
@@ -246,60 +270,15 @@ class TestSchemaVersioning:
             )
             stv = cur.fetchone()[0]
 
-        assert stv is not None, "systemTimeValidity must be set on INSERT"
-        # psycopg2 returns a DateTimeTZRange; PostgreSQL TIMESTAMPTZ 'infinity' is
-        # represented as 9999-12-31 by psycopg2, so upper_inf is False.
-        # We just verify the lower bound is finite (a real timestamp).
-        assert not stv.lower_inf, "Lower bound must be a real timestamp after INSERT"
-        assert stv.lower is not None, "Lower bound must not be None after INSERT"
-
-    def test_update_archives_old_row_to_history(self, schema):
-        """
-        On UPDATE the previous row version must appear in the history table
-        with a closed systemTimeValidity (finite upper bound).
-        """
-        with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "arch-thing")
-            cur.execute(
-                'UPDATE sensorthings."Thing" SET "description" = \'updated\' WHERE id = %s',
-                (thing_id,),
-            )
-            cur.execute(
-                'SELECT "systemTimeValidity" FROM sensorthings_history."Thing" WHERE id = %s',
-                (thing_id,),
-            )
-            rows = cur.fetchall()
-
-        assert len(rows) == 1, "Exactly one archived row should exist after one UPDATE"
-        stv = rows[0][0]
-        assert not stv.upper_inf, "Archived row must have a finite upper bound"
-
-    def test_update_live_row_gets_new_start(self, schema):
-        """
-        After UPDATE the live row's systemTimeValidity lower bound must be
-        strictly after the archived row's lower bound.
-        """
-        with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "stv-upd")
-            cur.execute(
-                'SELECT lower("systemTimeValidity") FROM sensorthings."Thing" WHERE id = %s',
-                (thing_id,),
-            )
-            t_before = cur.fetchone()[0]
-
-            cur.execute(
-                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
-                (thing_id,),
-            )
-            cur.execute(
-                'SELECT lower("systemTimeValidity") FROM sensorthings."Thing" WHERE id = %s',
-                (thing_id,),
-            )
-            t_after = cur.fetchone()[0]
-
-        assert t_after >= t_before
+        assert stv is not None
+        # psycopg2 maps PostgreSQL's TIMESTAMPTZ 'infinity' to datetime(9999-12-31),
+        # so upper_inf will be False even for a valid open-ended range. We only
+        # assert that the lower bound is a real timestamp.
+        assert not stv.lower_inf
+        assert stv.lower is not None
 
     def test_insert_sets_upper_infinite(self, schema):
+        """The upper bound after INSERT must be non-null (open-ended range)."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "stv-upper")
             cur.execute(
@@ -310,59 +289,33 @@ class TestSchemaVersioning:
 
         assert stv.upper is not None
 
-    def test_update_raises_on_id_change(self, schema):
-        """
-        Attempting to change the id column of a versioned row must raise an
-        exception from the istsos_mutate_history trigger.
-        """
-        with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "id-change")
-            with pytest.raises(psycopg2.errors.RaiseException, match="ID must not be changed"):
-                cur.execute(
-                    'UPDATE sensorthings."Thing" SET id = %s WHERE id = %s',
-                    (thing_id + 9999, thing_id),
-                )
-    
-    def test_delete_archives_row_to_history(self, schema):
-        """
-        On DELETE the row must be copied to the history table with an
-        inclusive, finite upper bound on systemTimeValidity.
-        """
-        with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "del-arch")
-            cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
+    # istsos_mutate_history() - UPDATE behavior
 
+    def test_update_archives_old_row_to_history(self, schema):
+        """UPDATE must copy the previous version to the history table."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "arch-thing")
+            cur.execute(
+                "UPDATE sensorthings.\"Thing\" SET \"description\" = 'updated' WHERE id = %s",
+                (thing_id,),
+            )
             cur.execute(
                 'SELECT "systemTimeValidity" FROM sensorthings_history."Thing" WHERE id = %s',
                 (thing_id,),
             )
             rows = cur.fetchall()
 
-        assert len(rows) == 1, "One archived row must exist after DELETE"
-        stv = rows[0][0]
-        assert not stv.upper_inf, "Deleted row must have a finite upper bound"
-        assert stv.upper_inc, "Deleted row's range must be upper-inclusive ([])"
-
-    def test_delete_removes_live_row(self, schema):
-        """After DELETE the live table must no longer contain the row."""
-        with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "del-live")
-            cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
-            cur.execute(
-                'SELECT id FROM sensorthings."Thing" WHERE id = %s', (thing_id,)
-            )
-            row = cur.fetchone()
-        assert row is None
+        assert len(rows) == 1, "exactly one archived row after one UPDATE"
+        assert not rows[0][0].upper_inf, "archived row must have a finite upper bound"
 
     def test_update_creates_single_history_entry(self, schema):
+        """One UPDATE must produce exactly one row in the history table."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "single-hist")
-
             cur.execute(
-                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                "UPDATE sensorthings.\"Thing\" SET \"description\" = 'v2' WHERE id = %s",
                 (thing_id,),
             )
-
             cur.execute(
                 'SELECT COUNT(*) FROM sensorthings_history."Thing" WHERE id = %s',
                 (thing_id,),
@@ -371,16 +324,87 @@ class TestSchemaVersioning:
 
         assert count == 1
 
+    def test_update_live_row_gets_new_start(self, schema):
+        """After UPDATE the live row's systemTimeValidity lower bound must advance."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "stv-upd")
+            cur.execute(
+                'SELECT lower("systemTimeValidity") FROM sensorthings."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            t_before = cur.fetchone()[0]
+
+            cur.execute(
+                "UPDATE sensorthings.\"Thing\" SET \"description\" = 'v2' WHERE id = %s",
+                (thing_id,),
+            )
+            cur.execute(
+                'SELECT lower("systemTimeValidity") FROM sensorthings."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            t_after = cur.fetchone()[0]
+
+        # current_timestamp is stable within a transaction, so t_after >= t_before.
+        assert t_after >= t_before
+
+    def test_update_raises_on_id_change(self, schema):
+        """Changing the id of a versioned row must raise an exception."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "id-change")
+            with pytest.raises(psycopg2.errors.RaiseException, match="ID must not be changed"):
+                cur.execute(
+                    'UPDATE sensorthings."Thing" SET id = %s WHERE id = %s',
+                    (thing_id + 9999, thing_id),
+                )
+
+    def test_multiple_updates_produce_ordered_history_chain(self, schema):
+        """
+        N updates must produce N archived rows with contiguous,
+        non-overlapping systemTimeValidity ranges.
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "chain-thing")
+
+            for i in range(3):
+                cur.execute(
+                    'UPDATE sensorthings."Thing" SET "description" = %s WHERE id = %s',
+                    (f"v{i + 2}", thing_id),
+                )
+
+            cur.execute(
+                """
+                SELECT lower("systemTimeValidity"), upper("systemTimeValidity")
+                FROM sensorthings_history."Thing"
+                WHERE id = %s
+                ORDER BY lower("systemTimeValidity")
+                """,
+                (thing_id,),
+            )
+            rows = cur.fetchall()
+
+        assert len(rows) == 3
+
+        # Each row's upper bound must equal the next row's lower bound.
+        for i in range(len(rows) - 1):
+            _, upper = rows[i]
+            next_lower, _ = rows[i + 1]
+            assert upper == next_lower, (
+                f"gap between history row {i} and {i + 1}: {upper} != {next_lower}"
+            )
+
+    # istsos_mutate_history() - skip-archiving paths
+
     def test_location_gen_foi_id_update_skips_history(self, schema):
         """
-        When only gen_foi_id changes on a Location row the trigger must
-        return early (RETURN NEW without archiving), so the history table
-        must remain empty for that row.
+        Updating only gen_foi_id on a Location must not produce a history row.
+
+        The trigger returns early for this column because it is set automatically
+        by the system (not a user-driven change) and should not create a new
+        version in the audit trail.
         """
         with schema.cursor() as cur:
             loc_id = self._insert_minimal_location(cur, "skip-foi-loc")
             foi_id = self._insert_minimal_foi(cur, "skip-gen-foi")
-
             cur.execute(
                 'UPDATE sensorthings."Location" SET "gen_foi_id" = %s WHERE id = %s',
                 (foi_id, loc_id),
@@ -391,13 +415,14 @@ class TestSchemaVersioning:
             )
             rows = cur.fetchall()
 
-        assert rows == [], (
-            "gen_foi_id-only update must NOT produce an archived row in the history table"
-        )
-    
+        assert rows == []
+
     def test_datastream_phenomenontime_update_skips_history(self, schema):
         """
-        Updating only phenomenonTime on a Datastream must not archive a row.
+        Updating only phenomenonTime on a Datastream must not produce a history row.
+
+        phenomenonTime is updated automatically as observations arrive and
+        should not create new versions in the audit trail.
         """
         with schema.cursor() as cur:
             ds_id, _, _ = self._setup_ds_foi(cur, suffix="skip-pt")
@@ -415,13 +440,14 @@ class TestSchemaVersioning:
             )
             rows = cur.fetchall()
 
-        assert rows == [], (
-            "phenomenonTime-only update must NOT produce an archived row"
-        )
+        assert rows == []
 
     def test_datastream_observedarea_update_skips_history(self, schema):
         """
-        Updating only observedArea on a Datastream must not archive a row.
+        Updating only observedArea on a Datastream must not produce a history row.
+
+        Like phenomenonTime, observedArea is maintained automatically and
+        is excluded from the versioning audit trail.
         """
         with schema.cursor() as cur:
             ds_id, _, _ = self._setup_ds_foi(cur, suffix="skip-oa")
@@ -439,15 +465,10 @@ class TestSchemaVersioning:
             )
             rows = cur.fetchall()
 
-        assert rows == [], (
-            "observedArea-only update must NOT produce an archived row"
-        )
+        assert rows == []
 
     def test_datastream_name_update_does_archive(self, schema):
-        """
-        Updating a 'normal' column (name) on a Datastream must archive the
-        old row — verifying the skip logic is column-specific.
-        """
+        """A regular column update on Datastream must produce a history row."""
         with schema.cursor() as cur:
             ds_id, _, _ = self._setup_ds_foi(cur, suffix="arch-ds")
             cur.execute(
@@ -460,13 +481,21 @@ class TestSchemaVersioning:
             )
             rows = cur.fetchall()
 
-        assert len(rows) == 1, "Name update must produce exactly one archived row"
+        assert len(rows) == 1
 
-    @pytest.mark.xfail(reason="Datastream skip logic incorrectly ignores mixed updates")
+    @pytest.mark.xfail(reason=(
+        "Bug in istsos_mutate_history: the Datastream skip condition uses OR, so any "
+        "update that touches observedArea or phenomenonTime bypasses archiving entirely, "
+        "even when other meaningful columns also changed. The condition should only skip "
+        "when the update is exclusively to those auto-managed columns."
+    ))
     def test_datastream_mixed_update_does_archive(self, schema):
+        """
+        Updating observedArea together with a regular column (name) must still
+        produce a history row.
+        """
         with schema.cursor() as cur:
             ds_id, _, _ = self._setup_ds_foi(cur, suffix="mixed")
-
             cur.execute(
                 """
                 UPDATE sensorthings."Datastream"
@@ -476,7 +505,6 @@ class TestSchemaVersioning:
                 """,
                 (ds_id,),
             )
-
             cur.execute(
                 'SELECT id FROM sensorthings_history."Datastream" WHERE id = %s',
                 (ds_id,),
@@ -485,15 +513,40 @@ class TestSchemaVersioning:
 
         assert len(rows) == 1
 
+    # istsos_mutate_history() - DELETE behavior
+
+    def test_delete_archives_row_to_history(self, schema):
+        """DELETE must copy the row to history with an upper-inclusive, finite range."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "del-arch")
+            cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
+            cur.execute(
+                'SELECT "systemTimeValidity" FROM sensorthings_history."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            rows = cur.fetchall()
+
+        assert len(rows) == 1
+        stv = rows[0][0]
+        assert not stv.upper_inf, "deleted row must have a finite upper bound"
+        assert stv.upper_inc, "deleted row range must be upper-inclusive ([])"
+
+    def test_delete_removes_live_row(self, schema):
+        """After DELETE the row must no longer appear in the live table."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "del-live")
+            cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
+            cur.execute('SELECT id FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
+            assert cur.fetchone() is None
+
+    # istsos_prevent_table_update()
+
     def test_history_table_update_raises(self, schema):
-        """
-        Any UPDATE on a history table must be rejected by the
-        istsos_prevent_table_update trigger.
-        """
+        """Any UPDATE on a history table must be rejected."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "prevent-upd")
             cur.execute(
-                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                "UPDATE sensorthings.\"Thing\" SET \"description\" = 'v2' WHERE id = %s",
                 (thing_id,),
             )
             with pytest.raises(
@@ -501,18 +554,16 @@ class TestSchemaVersioning:
                 match="Updates or Deletes on this table are not allowed",
             ):
                 cur.execute(
-                    'UPDATE sensorthings_history."Thing" SET "description" = \'hack\' WHERE id = %s',
+                    "UPDATE sensorthings_history.\"Thing\" SET \"description\" = 'hack' WHERE id = %s",
                     (thing_id,),
                 )
 
     def test_history_table_delete_raises(self, schema):
-        """
-        Any DELETE on a history table must be rejected.
-        """
+        """Any DELETE on a history table must be rejected."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "prevent-del")
             cur.execute(
-                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                "UPDATE sensorthings.\"Thing\" SET \"description\" = 'v2' WHERE id = %s",
                 (thing_id,),
             )
             with pytest.raises(
@@ -523,12 +574,11 @@ class TestSchemaVersioning:
                     'DELETE FROM sensorthings_history."Thing" WHERE id = %s',
                     (thing_id,),
                 )
-    
+
+    # add_table_to_versioning()
+
     def test_versioned_tables_have_system_time_validity_column(self, schema):
-        """
-        Every table in the canonical versioning list must expose a
-        systemTimeValidity column after schema setup.
-        """
+        """Every versioned table must have a systemTimeValidity column."""
         tables = [
             "Location", "Thing", "HistoricalLocation", "ObservedProperty",
             "Sensor", "Datastream", "FeaturesOfInterest", "Observation",
@@ -537,8 +587,7 @@ class TestSchemaVersioning:
             for table in tables:
                 cur.execute(
                     """
-                    SELECT column_name
-                    FROM information_schema.columns
+                    SELECT column_name FROM information_schema.columns
                     WHERE table_schema = 'sensorthings'
                       AND table_name = %s
                       AND column_name = 'systemTimeValidity'
@@ -546,30 +595,30 @@ class TestSchemaVersioning:
                     (table,),
                 )
                 assert cur.fetchone() is not None, (
-                    f"sensorthings.\"{table}\" must have a systemTimeValidity column"
+                    f'sensorthings."{table}" is missing systemTimeValidity'
                 )
-    
-    def test_history_exclusion_constraint_via_direct_insert(self, schema):
+
+    def test_history_exclusion_constraint_blocks_overlapping_insert(self, schema):
         """
-        Two direct INSERTs into the history table for the same id with
-        overlapping ranges must violate the exclusion constraint.
+        Two direct INSERTs into a history table for the same id with overlapping
+        systemTimeValidity ranges must raise an ExclusionViolation.
         """
         with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "excl2-thing")
+            thing_id = self._insert_minimal_thing(cur, "excl-thing")
 
-            # Fetch column list (excluding systemTimeValidity to override it)
+            # Build the column list without systemTimeValidity so we can
+            # supply a custom range for each INSERT.
             cur.execute(
                 """
                 SELECT column_name FROM information_schema.columns
                 WHERE table_schema = 'sensorthings' AND table_name = 'Thing'
                   AND column_name != 'systemTimeValidity'
                 ORDER BY ordinal_position
-                """
+                """,
             )
             cols = [r[0] for r in cur.fetchall()]
             col_list = ", ".join(f'"{c}"' for c in cols)
 
-            # First history INSERT — range [2020, 2021)
             cur.execute(
                 f"""
                 INSERT INTO sensorthings_history."Thing" ({col_list}, "systemTimeValidity")
@@ -579,7 +628,6 @@ class TestSchemaVersioning:
                 (thing_id,),
             )
 
-            # Second INSERT with overlapping range — must fail
             with pytest.raises(psycopg2.errors.ExclusionViolation):
                 cur.execute(
                     f"""
@@ -589,9 +637,11 @@ class TestSchemaVersioning:
                     """,
                     (thing_id,),
                 )
-    
+
+    # Traveltime view
+
     def test_traveltime_view_contains_live_row(self, schema):
-        """The _traveltime view must include the current live row."""
+        """The traveltime view must include the current live row."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "tt-live")
             cur.execute(
@@ -601,11 +651,11 @@ class TestSchemaVersioning:
             assert cur.fetchone() is not None
 
     def test_traveltime_view_contains_archived_row_after_update(self, schema):
-        """After an UPDATE the traveltime view must return both versions."""
+        """After UPDATE the traveltime view must expose both the old and new versions."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "tt-arch")
             cur.execute(
-                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                "UPDATE sensorthings.\"Thing\" SET \"description\" = 'v2' WHERE id = %s",
                 (thing_id,),
             )
             cur.execute(
@@ -613,12 +663,11 @@ class TestSchemaVersioning:
                 (thing_id,),
             )
             rows = cur.fetchall()
-        assert len(rows) == 2, (
-            "traveltime view must expose both the live row and the archived row"
-        )
+
+        assert len(rows) == 2
 
     def test_traveltime_view_contains_deleted_row(self, schema):
-        """After DELETE the traveltime view must still expose the deleted version."""
+        """After DELETE the traveltime view must still expose the deleted version via history."""
         with schema.cursor() as cur:
             thing_id = self._insert_minimal_thing(cur, "tt-del")
             cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
@@ -627,50 +676,41 @@ class TestSchemaVersioning:
                 (thing_id,),
             )
             rows = cur.fetchall()
-        assert len(rows) == 1, (
-            "Deleted row must still be visible through the traveltime view via history"
-        )
+
+        assert len(rows) == 1
 
     @pytest.mark.parametrize(
         "insert_fn, table, alias, expected_path",
         [
-            ("_insert_minimal_thing", "Thing_traveltime", "t", "Things"),
-            ("_insert_minimal_location", "Location_traveltime", "l", "Locations"),
-            ("_insert_minimal_sensor", "Sensor_traveltime", "s", "Sensors"),
-            ("_insert_minimal_observed_property", "ObservedProperty_traveltime", "op", "ObservedProperties"),
-            ("_setup_ds_foi", "Datastream_traveltime", "d", "Datastreams"),
-            ("_insert_minimal_foi", "FeaturesOfInterest_traveltime", "f", "FeaturesOfInterest"),
+            ("_insert_minimal_thing",             "Thing_traveltime",              "t",  "Things"),
+            ("_insert_minimal_location",          "Location_traveltime",           "l",  "Locations"),
+            ("_insert_minimal_sensor",            "Sensor_traveltime",             "s",  "Sensors"),
+            ("_insert_minimal_observed_property", "ObservedProperty_traveltime",   "op", "ObservedProperties"),
+            ("_setup_ds_foi",                     "Datastream_traveltime",         "d",  "Datastreams"),
+            ("_insert_minimal_foi",               "FeaturesOfInterest_traveltime", "f",  "FeaturesOfInterest"),
         ],
     )
-    def test_traveltime_selflink_generic(
-        self, schema, insert_fn, table, alias, expected_path
-    ):
+    def test_traveltime_selflink(self, schema, insert_fn, table, alias, expected_path):
+        """The @iot.selfLink function on each traveltime view must return the correct URL."""
         with schema.cursor() as cur:
             fn = getattr(self, insert_fn)
-
-            # Handle different function signatures
             if insert_fn == "_setup_ds_foi":
                 entity_id, *_ = fn(cur, suffix="tt-sl")
             else:
                 entity_id = fn(cur, "tt-sl")
 
             cur.execute(
-                f'''
-                SELECT "@iot.selfLink"({alias})
-                FROM sensorthings."{table}" {alias}
-                WHERE id = %s
-                ''',
+                f'SELECT "@iot.selfLink"({alias}) FROM sensorthings."{table}" {alias} WHERE id = %s',
                 (entity_id,),
             )
             link = cur.fetchone()[0]
 
         assert link == f"/{expected_path}({entity_id})"
 
-
     def test_traveltime_selflink_observation(self, schema):
+        """@iot.selfLink on Observation_traveltime must return '/Observations(<id>)'."""
         with schema.cursor() as cur:
             ds_id, foi_id, _ = self._setup_ds_foi(cur, suffix="tt-sl-obs")
-
             cur.execute(
                 """
                 INSERT INTO sensorthings."Observation"
@@ -680,82 +720,49 @@ class TestSchemaVersioning:
                 (ds_id, foi_id),
             )
             obs_id = cur.fetchone()[0]
-
             cur.execute(
-                '''
-                SELECT "@iot.selfLink"(o)
-                FROM sensorthings."Observation_traveltime" o
-                WHERE id = %s
-                ''',
+                'SELECT "@iot.selfLink"(o) FROM sensorthings."Observation_traveltime" o WHERE id = %s',
                 (obs_id,),
             )
             link = cur.fetchone()[0]
 
         assert link == f"/Observations({obs_id})"
 
-    def test_multiple_updates_produce_ordered_history_chain(self, schema):
-        with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "chain-thing")
-
-            for i in range(3):
-                cur.execute(
-                    'UPDATE sensorthings."Thing" SET "description" = %s WHERE id = %s',
-                    (f"v{i+2}", thing_id),
-                )
-
-            cur.execute(
-                """
-                SELECT lower("systemTimeValidity"), upper("systemTimeValidity")
-                FROM sensorthings_history."Thing"
-                WHERE id = %s
-                ORDER BY lower("systemTimeValidity")
-                """,
-                (thing_id,),
-            )
-            history_rows = cur.fetchall()
-
-        assert len(history_rows) == 3, "Three updates must produce three history rows"
-
-        # Verify contiguity: each upper bound == next lower bound
-        for i in range(len(history_rows) - 1):
-            _, upper = history_rows[i]
-            next_lower, _ = history_rows[i + 1]
-            assert upper == next_lower, (
-                f"History row {i} upper ({upper}) must equal row {i+1} lower ({next_lower})"
-            )
-
     def test_traveltime_observation_result_function(self, schema):
         """
-        The result() overload on Observation_traveltime must dispatch
-        correctly for each resultType just like the base Observation function.
+        The result() overload on Observation_traveltime must dispatch correctly
+        for each resultType, matching the behavior of the base Observation function.
         """
         cases = [
-            (0, {"resultNumber": 3.14}, 3.14),
-            (1, {"resultBoolean": True}, True),
-            (3, {"resultString": "hi"}, "hi"),
+            (0, "resultNumber", 3.14),
+            (1, "resultBoolean", True),
+            (3, "resultString",  "hi"),
         ]
-        col_map = {0: "resultNumber", 1: "resultBoolean", 3: "resultString"}
 
         with schema.cursor() as cur:
             ds_id, foi_id, _ = self._setup_ds_foi(cur, suffix="tt-result")
 
-            for result_type, kwargs, expected in cases:
-                col = col_map[result_type]
-                value = list(kwargs.values())[0]
+            for result_type, col, expected in cases:
                 cur.execute(
                     f"""
                     INSERT INTO sensorthings."Observation"
                         ("resultType", "{col}", "datastream_id",
                          "featuresofinterest_id", "phenomenonTime")
                     VALUES (%s, %s, %s, %s,
-                        tstzrange(now() + (%s || ' seconds')::interval,
-                                  now() + (%s || ' seconds')::interval, '[]'))
+                        tstzrange(
+                            now() + (%s || ' seconds')::interval,
+                            now() + (%s || ' seconds')::interval,
+                            '[]'
+                        ))
                     RETURNING id
                     """,
-                    (result_type, value, ds_id, foi_id, result_type * 10, result_type * 10),
+                    (result_type, expected, ds_id, foi_id,
+                     result_type * 10, result_type * 10),
                 )
                 obs_id = cur.fetchone()[0]
 
+                # Use ORDER BY + LIMIT to get the live version without relying on
+                # upper_inf, which psycopg2 misreports for TIMESTAMPTZ 'infinity'.
                 cur.execute(
                     """
                     SELECT result(o)

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -174,3 +174,49 @@ class TestSchemaVersioning:
         # We just verify the lower bound is finite (a real timestamp).
         assert not stv.lower_inf, "Lower bound must be a real timestamp after INSERT"
         assert stv.lower is not None, "Lower bound must not be None after INSERT"
+
+    def test_update_archives_old_row_to_history(self, schema):
+        """
+        On UPDATE the previous row version must appear in the history table
+        with a closed systemTimeValidity (finite upper bound).
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "arch-thing")
+            cur.execute(
+                'UPDATE sensorthings."Thing" SET "description" = \'updated\' WHERE id = %s',
+                (thing_id,),
+            )
+            cur.execute(
+                'SELECT "systemTimeValidity" FROM sensorthings_history."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            rows = cur.fetchall()
+
+        assert len(rows) == 1, "Exactly one archived row should exist after one UPDATE"
+        stv = rows[0][0]
+        assert not stv.upper_inf, "Archived row must have a finite upper bound"
+
+    def test_update_live_row_gets_new_start(self, schema):
+        """
+        After UPDATE the live row's systemTimeValidity lower bound must be
+        strictly after the archived row's lower bound.
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "stv-upd")
+            cur.execute(
+                'SELECT lower("systemTimeValidity") FROM sensorthings."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            t_before = cur.fetchone()[0]
+
+            cur.execute(
+                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                (thing_id,),
+            )
+            cur.execute(
+                'SELECT lower("systemTimeValidity") FROM sensorthings."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            t_after = cur.fetchone()[0]
+
+        assert t_after >= t_before

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -589,3 +589,44 @@ class TestSchemaVersioning:
                     """,
                     (thing_id,),
                 )
+    
+    def test_traveltime_view_contains_live_row(self, schema):
+        """The _traveltime view must include the current live row."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "tt-live")
+            cur.execute(
+                'SELECT id FROM sensorthings."Thing_traveltime" WHERE id = %s',
+                (thing_id,),
+            )
+            assert cur.fetchone() is not None
+
+    def test_traveltime_view_contains_archived_row_after_update(self, schema):
+        """After an UPDATE the traveltime view must return both versions."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "tt-arch")
+            cur.execute(
+                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                (thing_id,),
+            )
+            cur.execute(
+                'SELECT id FROM sensorthings."Thing_traveltime" WHERE id = %s',
+                (thing_id,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2, (
+            "traveltime view must expose both the live row and the archived row"
+        )
+
+    def test_traveltime_view_contains_deleted_row(self, schema):
+        """After DELETE the traveltime view must still expose the deleted version."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "tt-del")
+            cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
+            cur.execute(
+                'SELECT id FROM sensorthings."Thing_traveltime" WHERE id = %s',
+                (thing_id,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1, (
+            "Deleted row must still be visible through the traveltime view via history"
+        )

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -244,3 +244,34 @@ class TestSchemaVersioning:
                     'UPDATE sensorthings."Thing" SET id = %s WHERE id = %s',
                     (thing_id + 9999, thing_id),
                 )
+    
+    def test_delete_archives_row_to_history(self, schema):
+        """
+        On DELETE the row must be copied to the history table with an
+        inclusive, finite upper bound on systemTimeValidity.
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "del-arch")
+            cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
+
+            cur.execute(
+                'SELECT "systemTimeValidity" FROM sensorthings_history."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            rows = cur.fetchall()
+
+        assert len(rows) == 1, "One archived row must exist after DELETE"
+        stv = rows[0][0]
+        assert not stv.upper_inf, "Deleted row must have a finite upper bound"
+        assert stv.upper_inc, "Deleted row's range must be upper-inclusive ([])"
+
+    def test_delete_removes_live_row(self, schema):
+        """After DELETE the live table must no longer contain the row."""
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "del-live")
+            cur.execute('DELETE FROM sensorthings."Thing" WHERE id = %s', (thing_id,))
+            cur.execute(
+                'SELECT id FROM sensorthings."Thing" WHERE id = %s', (thing_id,)
+            )
+            row = cur.fetchone()
+        assert row is None

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -692,3 +692,34 @@ class TestSchemaVersioning:
             link = cur.fetchone()[0]
 
         assert link == f"/Observations({obs_id})"
+
+    def test_multiple_updates_produce_ordered_history_chain(self, schema):
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "chain-thing")
+
+            for i in range(3):
+                cur.execute(
+                    'UPDATE sensorthings."Thing" SET "description" = %s WHERE id = %s',
+                    (f"v{i+2}", thing_id),
+                )
+
+            cur.execute(
+                """
+                SELECT lower("systemTimeValidity"), upper("systemTimeValidity")
+                FROM sensorthings_history."Thing"
+                WHERE id = %s
+                ORDER BY lower("systemTimeValidity")
+                """,
+                (thing_id,),
+            )
+            history_rows = cur.fetchall()
+
+        assert len(history_rows) == 3, "Three updates must produce three history rows"
+
+        # Verify contiguity: each upper bound == next lower bound
+        for i in range(len(history_rows) - 1):
+            _, upper = history_rows[i]
+            next_lower, _ = history_rows[i + 1]
+            assert upper == next_lower, (
+                f"History row {i} upper ({upper}) must equal row {i+1} lower ({next_lower})"
+            )

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -630,70 +630,47 @@ class TestSchemaVersioning:
         assert len(rows) == 1, (
             "Deleted row must still be visible through the traveltime view via history"
         )
-    
-    def test_traveltime_selflink_thing(self, schema):
-        with schema.cursor() as cur:
-            thing_id = self._insert_minimal_thing(cur, "tt-sl-thing")
-            cur.execute(
-                'SELECT "@iot.selfLink"(t) FROM sensorthings."Thing_traveltime" t WHERE id = %s',
-                (thing_id,),
-            )
-            link = cur.fetchone()[0]
-        assert link == f"/Things({thing_id})"
 
-    def test_traveltime_selflink_location(self, schema):
+    @pytest.mark.parametrize(
+        "insert_fn, table, alias, expected_path",
+        [
+            ("_insert_minimal_thing", "Thing_traveltime", "t", "Things"),
+            ("_insert_minimal_location", "Location_traveltime", "l", "Locations"),
+            ("_insert_minimal_sensor", "Sensor_traveltime", "s", "Sensors"),
+            ("_insert_minimal_observed_property", "ObservedProperty_traveltime", "op", "ObservedProperties"),
+            ("_setup_ds_foi", "Datastream_traveltime", "d", "Datastreams"),
+            ("_insert_minimal_foi", "FeaturesOfInterest_traveltime", "f", "FeaturesOfInterest"),
+        ],
+    )
+    def test_traveltime_selflink_generic(
+        self, schema, insert_fn, table, alias, expected_path
+    ):
         with schema.cursor() as cur:
-            loc_id = self._insert_minimal_location(cur, "tt-sl-loc")
-            cur.execute(
-                'SELECT "@iot.selfLink"(l) FROM sensorthings."Location_traveltime" l WHERE id = %s',
-                (loc_id,),
-            )
-            link = cur.fetchone()[0]
-        assert link == f"/Locations({loc_id})"
+            fn = getattr(self, insert_fn)
 
-    def test_traveltime_selflink_sensor(self, schema):
-        with schema.cursor() as cur:
-            sensor_id = self._insert_minimal_sensor(cur, "tt-sl-sensor")
-            cur.execute(
-                'SELECT "@iot.selfLink"(s) FROM sensorthings."Sensor_traveltime" s WHERE id = %s',
-                (sensor_id,),
-            )
-            link = cur.fetchone()[0]
-        assert link == f"/Sensors({sensor_id})"
+            # Handle different function signatures
+            if insert_fn == "_setup_ds_foi":
+                entity_id, *_ = fn(cur, suffix="tt-sl")
+            else:
+                entity_id = fn(cur, "tt-sl")
 
-    def test_traveltime_selflink_observed_property(self, schema):
-        with schema.cursor() as cur:
-            op_id = self._insert_minimal_observed_property(cur, "tt-sl-op")
             cur.execute(
-                'SELECT "@iot.selfLink"(op) FROM sensorthings."ObservedProperty_traveltime" op WHERE id = %s',
-                (op_id,),
+                f'''
+                SELECT "@iot.selfLink"({alias})
+                FROM sensorthings."{table}" {alias}
+                WHERE id = %s
+                ''',
+                (entity_id,),
             )
             link = cur.fetchone()[0]
-        assert link == f"/ObservedProperties({op_id})"
 
-    def test_traveltime_selflink_datastream(self, schema):
-        with schema.cursor() as cur:
-            ds_id, _, _ = self._setup_ds_foi(cur, suffix="tt-sl-ds")
-            cur.execute(
-                'SELECT "@iot.selfLink"(d) FROM sensorthings."Datastream_traveltime" d WHERE id = %s',
-                (ds_id,),
-            )
-            link = cur.fetchone()[0]
-        assert link == f"/Datastreams({ds_id})"
+        assert link == f"/{expected_path}({entity_id})"
 
-    def test_traveltime_selflink_features_of_interest(self, schema):
-        with schema.cursor() as cur:
-            foi_id = self._insert_minimal_foi(cur, "tt-sl-foi")
-            cur.execute(
-                'SELECT "@iot.selfLink"(f) FROM sensorthings."FeaturesOfInterest_traveltime" f WHERE id = %s',
-                (foi_id,),
-            )
-            link = cur.fetchone()[0]
-        assert link == f"/FeaturesOfInterest({foi_id})"
 
     def test_traveltime_selflink_observation(self, schema):
         with schema.cursor() as cur:
             ds_id, foi_id, _ = self._setup_ds_foi(cur, suffix="tt-sl-obs")
+
             cur.execute(
                 """
                 INSERT INTO sensorthings."Observation"
@@ -703,9 +680,15 @@ class TestSchemaVersioning:
                 (ds_id, foi_id),
             )
             obs_id = cur.fetchone()[0]
+
             cur.execute(
-                'SELECT "@iot.selfLink"(o) FROM sensorthings."Observation_traveltime" o WHERE id = %s',
+                '''
+                SELECT "@iot.selfLink"(o)
+                FROM sensorthings."Observation_traveltime" o
+                WHERE id = %s
+                ''',
                 (obs_id,),
             )
             link = cur.fetchone()[0]
+
         assert link == f"/Observations({obs_id})"

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -548,3 +548,44 @@ class TestSchemaVersioning:
                 assert cur.fetchone() is not None, (
                     f"sensorthings.\"{table}\" must have a systemTimeValidity column"
                 )
+    
+    def test_history_exclusion_constraint_via_direct_insert(self, schema):
+        """
+        Two direct INSERTs into the history table for the same id with
+        overlapping ranges must violate the exclusion constraint.
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "excl2-thing")
+
+            # Fetch column list (excluding systemTimeValidity to override it)
+            cur.execute(
+                """
+                SELECT column_name FROM information_schema.columns
+                WHERE table_schema = 'sensorthings' AND table_name = 'Thing'
+                  AND column_name != 'systemTimeValidity'
+                ORDER BY ordinal_position
+                """
+            )
+            cols = [r[0] for r in cur.fetchall()]
+            col_list = ", ".join(f'"{c}"' for c in cols)
+
+            # First history INSERT — range [2020, 2021)
+            cur.execute(
+                f"""
+                INSERT INTO sensorthings_history."Thing" ({col_list}, "systemTimeValidity")
+                SELECT {col_list}, tstzrange('2020-01-01', '2021-01-01', '[)')
+                FROM sensorthings."Thing" WHERE id = %s
+                """,
+                (thing_id,),
+            )
+
+            # Second INSERT with overlapping range — must fail
+            with pytest.raises(psycopg2.errors.ExclusionViolation):
+                cur.execute(
+                    f"""
+                    INSERT INTO sensorthings_history."Thing" ({col_list}, "systemTimeValidity")
+                    SELECT {col_list}, tstzrange('2020-06-01', '2021-06-01', '[)')
+                    FROM sensorthings."Thing" WHERE id = %s
+                    """,
+                    (thing_id,),
+                )

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -231,3 +231,16 @@ class TestSchemaVersioning:
             stv = cur.fetchone()[0]
 
         assert stv.upper is not None
+
+    def test_update_raises_on_id_change(self, schema):
+        """
+        Attempting to change the id column of a versioned row must raise an
+        exception from the istsos_mutate_history trigger.
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "id-change")
+            with pytest.raises(psycopg2.errors.RaiseException, match="ID must not be changed"):
+                cur.execute(
+                    'UPDATE sensorthings."Thing" SET id = %s WHERE id = %s',
+                    (thing_id + 9999, thing_id),
+                )

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -275,3 +275,20 @@ class TestSchemaVersioning:
             )
             row = cur.fetchone()
         assert row is None
+
+    def test_update_creates_single_history_entry(self, schema):
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "single-hist")
+
+            cur.execute(
+                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                (thing_id,),
+            )
+
+            cur.execute(
+                'SELECT COUNT(*) FROM sensorthings_history."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            count = cur.fetchone()[0]
+
+        assert count == 1

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -143,7 +143,21 @@ class TestSchemaVersioning:
             (action,),
         )
         return self._get_id(cur.fetchone())
-
+    
+    def _insert_minimal_location(self, cur, name="v-loc"):
+        commit_id = self._insert_commit(cur)
+        cur.execute(
+            """
+            INSERT INTO sensorthings."Location"
+                ("name", "description", "encodingType", "location", "commit_id")
+            VALUES (%s, 'desc', 'application/geo+json',
+                    ST_SetSRID(ST_MakePoint(9.0, 46.0), 4326), %s)
+            RETURNING id
+            """,
+            (name, commit_id),
+        )
+        return self._get_id(cur.fetchone())
+    
     def _insert_minimal_thing(self, cur, name="v-thing"):
         commit_id = self._insert_commit(cur)
         cur.execute(
@@ -154,6 +168,70 @@ class TestSchemaVersioning:
             (name, commit_id),
         )
         return self._get_id(cur.fetchone())
+    
+    def _insert_minimal_sensor(self, cur, name="v-sensor"):
+        commit_id = self._insert_commit(cur)
+        cur.execute(
+            """
+            INSERT INTO sensorthings."Sensor"
+                ("name", "description", "encodingType", "metadata", "commit_id")
+            VALUES (%s, 'desc', 'application/pdf', 'http://meta', %s)
+            RETURNING id
+            """,
+            (name, commit_id),
+        )
+        return self._get_id(cur.fetchone())
+    
+    def _insert_minimal_observed_property(self, cur, name="v-op"):
+        commit_id = self._insert_commit(cur)
+        cur.execute(
+            """
+            INSERT INTO sensorthings."ObservedProperty"
+                ("name", "definition", "description", "commit_id")
+            VALUES (%s, 'http://def', 'desc', %s)
+            RETURNING id
+            """,
+            (name, commit_id),
+        )
+        return self._get_id(cur.fetchone())
+    
+    def _insert_minimal_datastream(self, cur, thing_id, sensor_id, op_id, name="v-ds"):
+        cur.execute(
+            """
+            INSERT INTO sensorthings."Datastream"
+                ("name", "description", "unitOfMeasurement",
+                 "observationType", "thing_id", "sensor_id", "observedproperty_id")
+            VALUES (%s, 'desc', '{"name":"C","symbol":"C","definition":"http://d"}'::jsonb,
+                    'http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement',
+                    %s, %s, %s)
+            RETURNING id
+            """,
+            (name, thing_id, sensor_id, op_id),
+        )
+        return self._get_id(cur.fetchone())
+    
+    def _insert_minimal_foi(self, cur, name="v-foi"):
+        cur.execute(
+            """
+            INSERT INTO sensorthings."FeaturesOfInterest"
+                ("name", "description", "encodingType", "feature")
+            VALUES (%s, 'desc', 'application/geo+json',
+                    ST_SetSRID(ST_MakePoint(9.0, 46.0), 4326))
+            RETURNING id
+            """,
+            (name,),
+        )
+        return self._get_id(cur.fetchone())
+
+    def _setup_ds_foi(self, cur, suffix="v"):
+        thing_id = self._insert_minimal_thing(cur, f"t-{suffix}")
+        sensor_id = self._insert_minimal_sensor(cur, f"s-{suffix}")
+        op_id = self._insert_minimal_observed_property(cur, f"op-{suffix}")
+        ds_id = self._insert_minimal_datastream(cur, thing_id, sensor_id, op_id, f"ds-{suffix}")
+        foi_id = self._insert_minimal_foi(cur, f"foi-{suffix}")
+        return ds_id, foi_id, thing_id
+
+    # Tests start
     
     def test_insert_sets_system_time_validity_start(self, schema):
         """
@@ -292,3 +370,94 @@ class TestSchemaVersioning:
             count = cur.fetchone()[0]
 
         assert count == 1
+
+    def test_location_gen_foi_id_update_skips_history(self, schema):
+        """
+        When only gen_foi_id changes on a Location row the trigger must
+        return early (RETURN NEW without archiving), so the history table
+        must remain empty for that row.
+        """
+        with schema.cursor() as cur:
+            loc_id = self._insert_minimal_location(cur, "skip-foi-loc")
+            foi_id = self._insert_minimal_foi(cur, "skip-gen-foi")
+
+            cur.execute(
+                'UPDATE sensorthings."Location" SET "gen_foi_id" = %s WHERE id = %s',
+                (foi_id, loc_id),
+            )
+            cur.execute(
+                'SELECT id FROM sensorthings_history."Location" WHERE id = %s',
+                (loc_id,),
+            )
+            rows = cur.fetchall()
+
+        assert rows == [], (
+            "gen_foi_id-only update must NOT produce an archived row in the history table"
+        )
+    
+    def test_datastream_phenomenontime_update_skips_history(self, schema):
+        """
+        Updating only phenomenonTime on a Datastream must not archive a row.
+        """
+        with schema.cursor() as cur:
+            ds_id, _, _ = self._setup_ds_foi(cur, suffix="skip-pt")
+            cur.execute(
+                """
+                UPDATE sensorthings."Datastream"
+                SET "phenomenonTime" = tstzrange(now(), now() + interval '1 hour')
+                WHERE id = %s
+                """,
+                (ds_id,),
+            )
+            cur.execute(
+                'SELECT id FROM sensorthings_history."Datastream" WHERE id = %s',
+                (ds_id,),
+            )
+            rows = cur.fetchall()
+
+        assert rows == [], (
+            "phenomenonTime-only update must NOT produce an archived row"
+        )
+
+    def test_datastream_observedarea_update_skips_history(self, schema):
+        """
+        Updating only observedArea on a Datastream must not archive a row.
+        """
+        with schema.cursor() as cur:
+            ds_id, _, _ = self._setup_ds_foi(cur, suffix="skip-oa")
+            cur.execute(
+                """
+                UPDATE sensorthings."Datastream"
+                SET "observedArea" = ST_SetSRID(ST_MakePoint(10.0, 47.0), 4326)
+                WHERE id = %s
+                """,
+                (ds_id,),
+            )
+            cur.execute(
+                'SELECT id FROM sensorthings_history."Datastream" WHERE id = %s',
+                (ds_id,),
+            )
+            rows = cur.fetchall()
+
+        assert rows == [], (
+            "observedArea-only update must NOT produce an archived row"
+        )
+
+    def test_datastream_name_update_does_archive(self, schema):
+        """
+        Updating a 'normal' column (name) on a Datastream must archive the
+        old row — verifying the skip logic is column-specific.
+        """
+        with schema.cursor() as cur:
+            ds_id, _, _ = self._setup_ds_foi(cur, suffix="arch-ds")
+            cur.execute(
+                "UPDATE sensorthings.\"Datastream\" SET \"name\" = 'renamed' WHERE id = %s",
+                (ds_id,),
+            )
+            cur.execute(
+                'SELECT id FROM sensorthings_history."Datastream" WHERE id = %s',
+                (ds_id,),
+            )
+            rows = cur.fetchall()
+
+        assert len(rows) == 1, "Name update must produce exactly one archived row"

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -461,3 +461,26 @@ class TestSchemaVersioning:
             rows = cur.fetchall()
 
         assert len(rows) == 1, "Name update must produce exactly one archived row"
+
+    @pytest.mark.xfail(reason="Datastream skip logic incorrectly ignores mixed updates")
+    def test_datastream_mixed_update_does_archive(self, schema):
+        with schema.cursor() as cur:
+            ds_id, _, _ = self._setup_ds_foi(cur, suffix="mixed")
+
+            cur.execute(
+                """
+                UPDATE sensorthings."Datastream"
+                SET "observedArea" = ST_SetSRID(ST_MakePoint(10.0, 47.0), 4326),
+                    "name" = 'changed'
+                WHERE id = %s
+                """,
+                (ds_id,),
+            )
+
+            cur.execute(
+                'SELECT id FROM sensorthings_history."Datastream" WHERE id = %s',
+                (ds_id,),
+            )
+            rows = cur.fetchall()
+
+        assert len(rows) == 1

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -630,3 +630,82 @@ class TestSchemaVersioning:
         assert len(rows) == 1, (
             "Deleted row must still be visible through the traveltime view via history"
         )
+    
+    def test_traveltime_selflink_thing(self, schema):
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "tt-sl-thing")
+            cur.execute(
+                'SELECT "@iot.selfLink"(t) FROM sensorthings."Thing_traveltime" t WHERE id = %s',
+                (thing_id,),
+            )
+            link = cur.fetchone()[0]
+        assert link == f"/Things({thing_id})"
+
+    def test_traveltime_selflink_location(self, schema):
+        with schema.cursor() as cur:
+            loc_id = self._insert_minimal_location(cur, "tt-sl-loc")
+            cur.execute(
+                'SELECT "@iot.selfLink"(l) FROM sensorthings."Location_traveltime" l WHERE id = %s',
+                (loc_id,),
+            )
+            link = cur.fetchone()[0]
+        assert link == f"/Locations({loc_id})"
+
+    def test_traveltime_selflink_sensor(self, schema):
+        with schema.cursor() as cur:
+            sensor_id = self._insert_minimal_sensor(cur, "tt-sl-sensor")
+            cur.execute(
+                'SELECT "@iot.selfLink"(s) FROM sensorthings."Sensor_traveltime" s WHERE id = %s',
+                (sensor_id,),
+            )
+            link = cur.fetchone()[0]
+        assert link == f"/Sensors({sensor_id})"
+
+    def test_traveltime_selflink_observed_property(self, schema):
+        with schema.cursor() as cur:
+            op_id = self._insert_minimal_observed_property(cur, "tt-sl-op")
+            cur.execute(
+                'SELECT "@iot.selfLink"(op) FROM sensorthings."ObservedProperty_traveltime" op WHERE id = %s',
+                (op_id,),
+            )
+            link = cur.fetchone()[0]
+        assert link == f"/ObservedProperties({op_id})"
+
+    def test_traveltime_selflink_datastream(self, schema):
+        with schema.cursor() as cur:
+            ds_id, _, _ = self._setup_ds_foi(cur, suffix="tt-sl-ds")
+            cur.execute(
+                'SELECT "@iot.selfLink"(d) FROM sensorthings."Datastream_traveltime" d WHERE id = %s',
+                (ds_id,),
+            )
+            link = cur.fetchone()[0]
+        assert link == f"/Datastreams({ds_id})"
+
+    def test_traveltime_selflink_features_of_interest(self, schema):
+        with schema.cursor() as cur:
+            foi_id = self._insert_minimal_foi(cur, "tt-sl-foi")
+            cur.execute(
+                'SELECT "@iot.selfLink"(f) FROM sensorthings."FeaturesOfInterest_traveltime" f WHERE id = %s',
+                (foi_id,),
+            )
+            link = cur.fetchone()[0]
+        assert link == f"/FeaturesOfInterest({foi_id})"
+
+    def test_traveltime_selflink_observation(self, schema):
+        with schema.cursor() as cur:
+            ds_id, foi_id, _ = self._setup_ds_foi(cur, suffix="tt-sl-obs")
+            cur.execute(
+                """
+                INSERT INTO sensorthings."Observation"
+                    ("resultType", "resultString", "datastream_id", "featuresofinterest_id")
+                VALUES (3, 'x', %s, %s) RETURNING id
+                """,
+                (ds_id, foi_id),
+            )
+            obs_id = cur.fetchone()[0]
+            cur.execute(
+                'SELECT "@iot.selfLink"(o) FROM sensorthings."Observation_traveltime" o WHERE id = %s',
+                (obs_id,),
+            )
+            link = cur.fetchone()[0]
+        assert link == f"/Observations({obs_id})"

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -484,3 +484,42 @@ class TestSchemaVersioning:
             rows = cur.fetchall()
 
         assert len(rows) == 1
+
+    def test_history_table_update_raises(self, schema):
+        """
+        Any UPDATE on a history table must be rejected by the
+        istsos_prevent_table_update trigger.
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "prevent-upd")
+            cur.execute(
+                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                (thing_id,),
+            )
+            with pytest.raises(
+                psycopg2.errors.RaiseException,
+                match="Updates or Deletes on this table are not allowed",
+            ):
+                cur.execute(
+                    'UPDATE sensorthings_history."Thing" SET "description" = \'hack\' WHERE id = %s',
+                    (thing_id,),
+                )
+
+    def test_history_table_delete_raises(self, schema):
+        """
+        Any DELETE on a history table must be rejected.
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "prevent-del")
+            cur.execute(
+                'UPDATE sensorthings."Thing" SET "description" = \'v2\' WHERE id = %s',
+                (thing_id,),
+            )
+            with pytest.raises(
+                psycopg2.errors.RaiseException,
+                match="Updates or Deletes on this table are not allowed",
+            ):
+                cur.execute(
+                    'DELETE FROM sensorthings_history."Thing" WHERE id = %s',
+                    (thing_id,),
+                )

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -523,3 +523,28 @@ class TestSchemaVersioning:
                     'DELETE FROM sensorthings_history."Thing" WHERE id = %s',
                     (thing_id,),
                 )
+    
+    def test_versioned_tables_have_system_time_validity_column(self, schema):
+        """
+        Every table in the canonical versioning list must expose a
+        systemTimeValidity column after schema setup.
+        """
+        tables = [
+            "Location", "Thing", "HistoricalLocation", "ObservedProperty",
+            "Sensor", "Datastream", "FeaturesOfInterest", "Observation",
+        ]
+        with schema.cursor() as cur:
+            for table in tables:
+                cur.execute(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = 'sensorthings'
+                      AND table_name = %s
+                      AND column_name = 'systemTimeValidity'
+                    """,
+                    (table,),
+                )
+                assert cur.fetchone() is not None, (
+                    f"sensorthings.\"{table}\" must have a systemTimeValidity column"
+                )

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -1,0 +1,176 @@
+"""
+Test module for schema versioning
+
+Run with:
+    pytest test/test_schema_versioning.py -v
+"""
+
+import pathlib
+import psycopg2
+import pytest
+
+SCHEMA_PATH = pathlib.Path(__file__).parent.parent / "database" / "istsos_schema.sql"
+VERSIONING_PATH = pathlib.Path(__file__).parent.parent / "database" / "istsos_schema_versioning.sql"
+
+DSN = "postgresql://postgres:15889@localhost:5432/istsos_versioning_test"
+ADMIN_DSN = "postgresql://postgres:15889@localhost:5432/postgres"
+TEST_DB = "istsos_versioning_test"
+
+
+# DB bootstrap helpers
+
+def _get_raw_conn(dsn=DSN):
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    return conn
+
+
+def _recreate_database():
+    # Step 1: terminate connections and drop the versioning test DB
+    admin_conn = psycopg2.connect(ADMIN_DSN)
+    admin_conn.autocommit = True
+    with admin_conn.cursor() as cur:
+        cur.execute(f"""
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = '{TEST_DB}' AND pid <> pg_backend_pid();
+        """)
+        cur.execute(f"DROP DATABASE IF EXISTS {TEST_DB}")
+    admin_conn.close()
+
+    # Step 2: connect to each *other* database that may hold objects owned by
+    # the roles we want to drop, and run DROP OWNED BY there first.
+    # We discover all non-template databases dynamically so this stays robust
+    # when test_schema.py has already created istsos_test with owned objects.
+    discover_conn = psycopg2.connect(ADMIN_DSN)
+    discover_conn.autocommit = True
+    with discover_conn.cursor() as cur:
+        cur.execute("""
+            SELECT datname FROM pg_database
+            WHERE datistemplate = false AND datname NOT IN ('postgres')
+        """)
+        other_dbs = [r[0] for r in cur.fetchall()]
+    discover_conn.close()
+
+    for db in other_dbs:
+        try:
+            db_conn = psycopg2.connect(f"postgresql://postgres:15889@localhost:5432/{db}")
+            db_conn.autocommit = True
+            with db_conn.cursor() as cur:
+                for role in ("administrator", "testuser"):
+                    cur.execute(f"""
+                        DO $$ BEGIN
+                            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                                DROP OWNED BY "{role}" CASCADE;
+                            END IF;
+                        END $$;
+                    """)
+            db_conn.close()
+        except Exception:
+            pass  # DB may have been dropped mid-loop; skip silently
+
+    # Step 3: now the roles have no dependents - safe to drop them
+    admin_conn = psycopg2.connect(ADMIN_DSN)
+    admin_conn.autocommit = True
+    with admin_conn.cursor() as cur:
+        cur.execute("DROP ROLE IF EXISTS administrator")
+        cur.execute("DROP ROLE IF EXISTS testuser")
+        cur.execute(f"CREATE DATABASE {TEST_DB}")
+    admin_conn.close()
+
+
+def _load_schema(conn):
+    sql = SCHEMA_PATH.read_text()
+    with conn.cursor() as cur:
+        cur.execute("SET custom.epsg = '4326'")
+        cur.execute("SET custom.duplicates = 'false'")
+        cur.execute("SET custom.network = 'false'")
+        cur.execute("SET custom.versioning = 'true'")
+        cur.execute('SET "custom.authorization" = \'false\'')
+        cur.execute('SET "custom.user" = \'testuser\'')
+        cur.execute("SET custom.password = 'testpassword'")
+        cur.execute(sql)
+
+
+def _load_versioning(conn):
+    sql = VERSIONING_PATH.read_text()
+    with conn.cursor() as cur:
+        cur.execute("SET custom.epsg = '4326'")
+        cur.execute("SET custom.network = 'false'")
+        cur.execute("SET custom.versioning = 'true'")
+        cur.execute('SET "custom.authorization" = \'false\'')
+        cur.execute(sql)
+
+
+class TestSchemaVersioning:
+    """
+    All tests share one schema+versioning load per session.
+    Each test rolls back its own data changes via the `rollback` fixture.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def schema(self):
+        _recreate_database()
+        setup_conn = _get_raw_conn()
+        _load_schema(setup_conn)
+        _load_versioning(setup_conn)
+        setup_conn.close()
+
+        conn = psycopg2.connect(DSN)
+        conn.autocommit = False
+        yield conn
+        conn.close()
+
+    @pytest.fixture(autouse=True)
+    def rollback(self, schema):
+        yield
+        schema.rollback()
+
+    # Row insertion helpers
+
+    def _get_id(self, row):
+        return row[0] if not isinstance(row, dict) else row["id"]
+
+    def _insert_commit(self, cur, action="CREATE"):
+        """Insert a Commit row (required by versioning) and return its id."""
+        cur.execute(
+            """
+            INSERT INTO sensorthings."Commit"
+                ("author", "message", "actionType")
+            VALUES ('test-author', 'test commit', %s)
+            RETURNING id
+            """,
+            (action,),
+        )
+        return self._get_id(cur.fetchone())
+
+    def _insert_minimal_thing(self, cur, name="v-thing"):
+        commit_id = self._insert_commit(cur)
+        cur.execute(
+            """
+            INSERT INTO sensorthings."Thing" ("name", "description", "commit_id")
+            VALUES (%s, 'desc', %s) RETURNING id
+            """,
+            (name, commit_id),
+        )
+        return self._get_id(cur.fetchone())
+    
+    def test_insert_sets_system_time_validity_start(self, schema):
+        """
+        After INSERT the live row must have systemTimeValidity =
+        [some finite lower bound, infinity).
+        """
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "stv-insert")
+            cur.execute(
+                'SELECT "systemTimeValidity" FROM sensorthings."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            stv = cur.fetchone()[0]
+
+        assert stv is not None, "systemTimeValidity must be set on INSERT"
+        # psycopg2 returns a DateTimeTZRange; PostgreSQL TIMESTAMPTZ 'infinity' is
+        # represented as 9999-12-31 by psycopg2, so upper_inf is False.
+        # We just verify the lower bound is finite (a real timestamp).
+        assert not stv.lower_inf, "Lower bound must be a real timestamp after INSERT"
+        assert stv.lower is not None, "Lower bound must not be None after INSERT"

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -723,3 +723,50 @@ class TestSchemaVersioning:
             assert upper == next_lower, (
                 f"History row {i} upper ({upper}) must equal row {i+1} lower ({next_lower})"
             )
+
+    def test_traveltime_observation_result_function(self, schema):
+        """
+        The result() overload on Observation_traveltime must dispatch
+        correctly for each resultType just like the base Observation function.
+        """
+        cases = [
+            (0, {"resultNumber": 3.14}, 3.14),
+            (1, {"resultBoolean": True}, True),
+            (3, {"resultString": "hi"}, "hi"),
+        ]
+        col_map = {0: "resultNumber", 1: "resultBoolean", 3: "resultString"}
+
+        with schema.cursor() as cur:
+            ds_id, foi_id, _ = self._setup_ds_foi(cur, suffix="tt-result")
+
+            for result_type, kwargs, expected in cases:
+                col = col_map[result_type]
+                value = list(kwargs.values())[0]
+                cur.execute(
+                    f"""
+                    INSERT INTO sensorthings."Observation"
+                        ("resultType", "{col}", "datastream_id",
+                         "featuresofinterest_id", "phenomenonTime")
+                    VALUES (%s, %s, %s, %s,
+                        tstzrange(now() + (%s || ' seconds')::interval,
+                                  now() + (%s || ' seconds')::interval, '[]'))
+                    RETURNING id
+                    """,
+                    (result_type, value, ds_id, foi_id, result_type * 10, result_type * 10),
+                )
+                obs_id = cur.fetchone()[0]
+
+                cur.execute(
+                    """
+                    SELECT result(o)
+                    FROM sensorthings."Observation_traveltime" o
+                    WHERE id = %s
+                    ORDER BY lower("systemTimeValidity") DESC
+                    LIMIT 1
+                    """,
+                    (obs_id,),
+                )
+                actual = cur.fetchone()[0]
+                assert actual == expected, (
+                    f"resultType {result_type}: expected {expected!r}, got {actual!r}"
+                )

--- a/test/test_schema_versioning.py
+++ b/test/test_schema_versioning.py
@@ -220,3 +220,14 @@ class TestSchemaVersioning:
             t_after = cur.fetchone()[0]
 
         assert t_after >= t_before
+
+    def test_insert_sets_upper_infinite(self, schema):
+        with schema.cursor() as cur:
+            thing_id = self._insert_minimal_thing(cur, "stv-upper")
+            cur.execute(
+                'SELECT "systemTimeValidity" FROM sensorthings."Thing" WHERE id = %s',
+                (thing_id,),
+            )
+            stv = cur.fetchone()[0]
+
+        assert stv.upper is not None


### PR DESCRIPTION
## Context

Adds an integration test suite for `istsos_schema_versioning.sql`, validating system-versioned behavior across SensorThings tables.

Tests run directly using `psycopg2` against a real PostgreSQL instance. The schema is loaded once per class, and each test runs inside a transaction with rollback isolation.

---

## istsos_mutate_history() trigger

Covers versioning behavior for all mutations:

- **INSERT**
  - Initializes `systemTimeValidity` correctly (finite lower bound, open upper bound)

- **UPDATE**
  - Archives previous row into history table
  - Ensures one history entry per update
  - Updates live row validity range
  - Rejects ID mutation
  - Multiple updates form a contiguous history chain

- **DELETE**
  - Archives deleted row with finite, upper-inclusive range
  - Removes row from live table

- **Skip logic**
  - No history entry for auto-managed fields:
    - `Location.gen_foi_id`
    - `Datastream.phenomenonTime`
    - `Datastream.observedArea`
  - Regular updates still archive correctly

- **Known issue (xfail)**
  - Mixed updates on `Datastream` incorrectly skip archiving due to OR-based condition

---

## History table protection

- UPDATE and DELETE on history tables are blocked via trigger

---

## Schema validation

- All versioned tables include `systemTimeValidity`
- Exclusion constraint prevents overlapping validity ranges

---

## Traveltime views

- Exposes both live and historical rows correctly
- Deleted rows remain accessible via history
- `@iot.selfLink` returns correct OGC paths for all entities
- `Observation_traveltime.result()` matches base behavior

---

## Notes

- Database is recreated once per test class
- psycopg2 handling of `TIMESTAMPTZ 'infinity'` is accounted for
- Known Datastream bug is explicitly captured via xfail, will be fixed in the next PR