### PR TITLE
fix(schema): correct Datastream versioning trigger to handle mixed updates correctly

### DIFF
--- a/database/istsos_schema_versioning.sql
+++ b/database/istsos_schema_versioning.sql
@@ -40,8 +40,14 @@ BEGIN
 
         -- If the table is 'Datastream' and the column 'phenomenonTime' or columns 'observedArea' exist  and are updated
         IF TG_TABLE_NAME = 'Datastream' THEN
-            IF (NEW."phenomenonTime" IS DISTINCT FROM OLD."phenomenonTime") OR (NEW."observedArea" IS DISTINCT FROM OLD."observedArea") THEN
-                -- Skip systemTimeValidity update
+            IF (
+                (NEW."phenomenonTime" IS DISTINCT FROM OLD."phenomenonTime" OR NEW."observedArea" IS DISTINCT FROM OLD."observedArea")
+                AND NEW."name" IS NOT DISTINCT FROM OLD."name"
+                AND NEW."description" IS NOT DISTINCT FROM OLD."description"
+                AND NEW."unitOfMeasurement" IS NOT DISTINCT FROM OLD."unitOfMeasurement"
+                AND NEW."observationType" IS NOT DISTINCT FROM OLD."observationType"
+                AND NEW."properties" IS NOT DISTINCT FROM OLD."properties"
+            ) THEN
                 RETURN NEW;
             END IF;
         END IF;


### PR DESCRIPTION
## Context

Fixes incorrect skip-archiving logic in `istsos_mutate_history` trigger for `Datastream`, discovered by tests in #140.

The previous implementation used an OR condition:

```sql
NEW."phenomenonTime" IS DISTINCT FROM OLD."phenomenonTime"
OR NEW."observedArea" IS DISTINCT FROM OLD."observedArea"
```

#### This caused:
- Mixed updates (auto-managed + user fields) to skip archiving entirely
- Loss of valid history entries for meaningful changes
- Incorrect audit trail behavior

## Changes
- Updated condition to skip only when changes are limited to auto-managed fields
- Ensures other column updates still trigger proper versioning
## Result
- Mixed updates now correctly archive previous versions
- Skip logic applies only to purely auto-managed updates
- Temporal history integrity is preserved
## Tests
- Previously failing mixed-update test now passes
- All tests pass