### PR TITLE
fix(cache): add TTL and write-invalidation to Redis cache layer

### DIFF
--- a/api/app/db/redis_db.py
+++ b/api/app/db/redis_db.py
@@ -12,30 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import redis
+import os
 
-redis = redis.Redis(host="redis")
+import redis as _redis_lib
+
+redis = _redis_lib.Redis(host="redis")
+
+# How long (in seconds) a cached query plan stays in Redis before auto-expiring.
+# Override via the REDIS_CACHE_TTL environment variable.
+CACHE_TTL = int(os.getenv("REDIS_CACHE_TTL", "300"))
 
 
-def remove_cache(path):
-    """
-    Remove the cache for the specified path.
+def set_cache(key: str, value: str) -> None:
+    """Store *value* under *key* in Redis with a fixed TTL.
+
+    Using a TTL ensures stale entries are automatically evicted even if
+    the corresponding write-path cache invalidation is somehow missed.
 
     Args:
-        path (str): The path to remove the cache for.
-
-    Returns:
-        None
+        key:   The cache key (typically the request URL path + query string).
+        value: The JSON-serialised query plan to cache.
     """
-    # Pattern da cercare nelle chiavi (ad esempio 'testop')
-    pattern = "*{}*".format(path)
+    redis.set(key, value, ex=CACHE_TTL)
 
-    # Itera su tutte le chiavi che corrispondono al pattern
+
+def remove_cache(entity: str) -> None:
+    """Delete all Redis cache entries that mention *entity* in their key.
+
+    Called by create / update / delete endpoints so that subsequent GET
+    requests re-fetch fresh data from the database instead of serving a
+    stale cached query plan.
+
+    Args:
+        entity: The SensorThings entity name, e.g. ``"Things"``, ``"Sensors"``,
+                ``"Observations"``, ``"Datastreams"``, etc.  The scan pattern
+                used is ``*/<entity>*`` so it matches collection and single-item
+                paths (``/Things``, ``/Things(1)``, ``/Things(1)/Datastreams``…)
+                without accidentally invalidating unrelated entity caches.
+    """
+    pattern = f"*/{entity}*"
     cursor = 0
     while True:
         cursor, keys = redis.scan(cursor=cursor, match=pattern)
         if keys:
-            # Cancella le chiavi trovate
             redis.delete(*keys)
         if cursor == 0:
             break
+

--- a/api/app/sta2rest/visitors.py
+++ b/api/app/sta2rest/visitors.py
@@ -24,7 +24,7 @@ from app import (
     VERSION,
     VERSIONING,
 )
-from app.db.redis_db import redis
+from app.db.redis_db import set_cache
 from app.db.sqlalchemy_db import engine
 from app.models import *
 from app.sta2rest import sta2rest
@@ -936,7 +936,7 @@ class NodeVisitor(Visitor):
         }
 
         if REDIS:
-            redis.set(self.full_path, json.dumps(main_query))
+            set_cache(self.full_path, json.dumps(main_query))
 
         return main_query
 

--- a/api/app/v1/endpoints/create/datastream.py
+++ b/api/app/v1/endpoints/create/datastream.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -109,6 +110,7 @@ async def create_datastream(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Datastreams")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},
@@ -194,6 +196,7 @@ async def create_datastream_for_thing(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Datastreams")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},
@@ -282,6 +285,7 @@ async def create_datastream_for_sensor(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Datastreams")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},
@@ -370,6 +374,7 @@ async def create_datastream_for_observed_property(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Datastreams")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},

--- a/api/app/v1/endpoints/create/feature_of_interest.py
+++ b/api/app/v1/endpoints/create/feature_of_interest.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -96,6 +97,7 @@ async def create_feature_of_interest(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("FeaturesOfInterest")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},

--- a/api/app/v1/endpoints/create/location.py
+++ b/api/app/v1/endpoints/create/location.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -96,6 +97,7 @@ async def create_location(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Locations")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},
@@ -168,6 +170,7 @@ async def create_location_for_thing(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Locations")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},

--- a/api/app/v1/endpoints/create/observation.py
+++ b/api/app/v1/endpoints/create/observation.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError, UniqueViolationError
@@ -96,6 +97,8 @@ async def create_observation(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Observations")
+        remove_cache("Datastreams")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},
@@ -185,6 +188,8 @@ async def create_observation_for_datastream(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Observations")
+        remove_cache("Datastreams")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},
@@ -266,6 +271,8 @@ async def create_observation_for_feature_of_interest(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Observations")
+        remove_cache("Datastreams")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},

--- a/api/app/v1/endpoints/create/observed_property.py
+++ b/api/app/v1/endpoints/create/observed_property.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -94,6 +95,7 @@ async def create_observed_property(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("ObservedProperties")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},

--- a/api/app/v1/endpoints/create/sensor.py
+++ b/api/app/v1/endpoints/create/sensor.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -96,6 +97,7 @@ async def create_sensor(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Sensors")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},

--- a/api/app/v1/endpoints/create/thing.py
+++ b/api/app/v1/endpoints/create/thing.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys, validate_required_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -94,6 +95,7 @@ async def create_thing(
 
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
+        remove_cache("Things")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},
@@ -167,6 +169,7 @@ async def create_thing_for_location(
                 if current_user is not None:
                     payload["user_id"] = current_user["id"]
 
+        remove_cache("Things")
         return Response(
             status_code=status.HTTP_201_CREATED,
             headers={"location": header},

--- a/api/app/v1/endpoints/delete/datastream.py
+++ b/api/app/v1/endpoints/delete/datastream.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Depends, Header, status
@@ -83,6 +84,7 @@ async def delete_datastream(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Datastreams")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(

--- a/api/app/v1/endpoints/delete/observation.py
+++ b/api/app/v1/endpoints/delete/observation.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.v1.endpoints.functions import set_role, update_datastream_observedArea
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Depends, Header, status
@@ -103,6 +104,8 @@ async def delete_observation(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Observations")
+        remove_cache("Datastreams")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(

--- a/api/app/v1/endpoints/delete/sensor.py
+++ b/api/app/v1/endpoints/delete/sensor.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Depends, Header, status
@@ -83,6 +84,7 @@ async def delete_sensor(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Sensors")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(

--- a/api/app/v1/endpoints/delete/thing.py
+++ b/api/app/v1/endpoints/delete/thing.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
 from fastapi import APIRouter, Depends, Header, status
@@ -81,6 +82,7 @@ async def delete_thing(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Things")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(

--- a/api/app/v1/endpoints/update/datastream.py
+++ b/api/app/v1/endpoints/update/datastream.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -128,6 +129,7 @@ async def update_datastream(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Datastreams")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(

--- a/api/app/v1/endpoints/update/observation.py
+++ b/api/app/v1/endpoints/update/observation.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys
 from app.v1.endpoints.functions import set_role, update_datastream_observedArea
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -160,6 +161,8 @@ async def update_observation(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Observations")
+        remove_cache("Datastreams")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(

--- a/api/app/v1/endpoints/update/sensor.py
+++ b/api/app/v1/endpoints/update/sensor.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -109,6 +110,7 @@ async def update_sensor(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Sensors")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(

--- a/api/app/v1/endpoints/update/thing.py
+++ b/api/app/v1/endpoints/update/thing.py
@@ -14,6 +14,7 @@
 
 from app import AUTHORIZATION, POSTGRES_PORT_WRITE, VERSIONING
 from app.db.asyncpg_db import get_pool, get_pool_w
+from app.db.redis_db import remove_cache
 from app.utils.utils import validate_payload_keys
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError
@@ -106,6 +107,7 @@ async def update_thing(
                 if current_user is not None:
                     await connection.execute("RESET ROLE;")
 
+        remove_cache("Things")
         return Response(status_code=status.HTTP_200_OK)
     except InsufficientPrivilegeError:
         return JSONResponse(


### PR DESCRIPTION
When `REDIS=1`, the API caches compiled query plans so repeated GET requests skip the query-building step. Two bugs meant the cache was never correctly managed, causing GET endpoints to return outdated data indefinitely after any write.
 
---
 
## The bugs
 
### Bug 1 - no TTL on cached entries
 
Every cache write used a bare `redis.set()` with no expiry:
 
```python
# visitors.py — before
redis.set(self.full_path, json.dumps(main_query))
```
 
Entries lived in Redis forever. Even restarting the server wouldn't help since Redis persists across restarts.
 
### Bug 2 -  `remove_cache()` defined but never called
 
`redis_db.py` has a `remove_cache()` helper, but it was never called from any create, update, or delete endpoint. After any write, the stale GET response kept being served from cache:
 
```
GET /Things          → []             (cached ✓)
POST /Things         → 201 Created    (DB write ✓)
GET /Things          → []             (stale cache served ✗)
```
 
---
 
## The fix
 
**Added `set_cache()` with TTL** — wraps `redis.set()` and always passes `ex=CACHE_TTL` (default 300s, configurable via `REDIS_CACHE_TTL` env var). Acts as a safety net even if invalidation is missed.
 
```python
CACHE_TTL = int(os.getenv("REDIS_CACHE_TTL", "300"))
 
def set_cache(key: str, value: str) -> None:
    redis.set(key, value, ex=CACHE_TTL)
```
 
**Improved `remove_cache()` pattern**  changed from a generic `*path*` glob to an entity-scoped `*/EntityName*` pattern, so clearing `Things` doesn't accidentally hit `Datastreams` or other unrelated keys.
 
**Wired `remove_cache()` into all mutating endpoints**  after every successful DB transaction in create, update, and delete handlers, the relevant entity's cache is cleared.
 
> Observation mutations also clear the `Datastreams` cache since they update the parent Datastream's `phenomenonTime` aggregate.
 
---
 
## Cache invalidation coverage
 
| Entity | Create | Update | Delete |
|---|---|---|---|
| Things | ✓ | ✓ | ✓ |
| Sensors | ✓ | ✓ | ✓ |
| Datastreams | ✓ (4 routes) | ✓ | ✓ |
| Observations | ✓ (3 routes) | ✓ | ✓ |
| Locations | ✓ (2 routes) | — | — |
| ObservedProperties | ✓ | — | — |
| FeaturesOfInterest | ✓ | — | — |
 
---
 
## Files changed
 
| File | Change |
|---|---|
| `api/app/db/redis_db.py` | `CACHE_TTL`, `set_cache()`, improved `remove_cache()` |
| `api/app/sta2rest/visitors.py` | use `set_cache()` instead of `redis.set()` |
| `api/app/v1/endpoints/create/thing.py` | `remove_cache("Things")` |
| `api/app/v1/endpoints/create/sensor.py` | `remove_cache("Sensors")` |
| `api/app/v1/endpoints/create/datastream.py` | `remove_cache("Datastreams")` |
| `api/app/v1/endpoints/create/observation.py` | `remove_cache("Observations")` + `("Datastreams")` |
| `api/app/v1/endpoints/create/location.py` | `remove_cache("Locations")` |
| `api/app/v1/endpoints/create/observed_property.py` | `remove_cache("ObservedProperties")` |
| `api/app/v1/endpoints/create/feature_of_interest.py` | `remove_cache("FeaturesOfInterest")` |
| `api/app/v1/endpoints/delete/thing.py` | `remove_cache("Things")` |
| `api/app/v1/endpoints/delete/sensor.py` | `remove_cache("Sensors")` |
| `api/app/v1/endpoints/delete/datastream.py` | `remove_cache("Datastreams")` |
| `api/app/v1/endpoints/delete/observation.py` | `remove_cache("Observations")` + `("Datastreams")` |
| `api/app/v1/endpoints/update/thing.py` | `remove_cache("Things")` |
| `api/app/v1/endpoints/update/sensor.py` | `remove_cache("Sensors")` |
| `api/app/v1/endpoints/update/datastream.py` | `remove_cache("Datastreams")` |
| `api/app/v1/endpoints/update/observation.py` | `remove_cache("Observations")` + `("Datastreams")` |
 
---
 
## How to verify
 
Run with `REDIS=1` and try:
 
```bash
curl http://localhost:8000/v1.1/Things
# → {"value": []}
 
curl -X POST http://localhost:8000/v1.1/Things \
  -H "Content-Type: application/json" \
  -d '{"name":"Station A","description":"test"}'
# → 201 Created
 
curl http://localhost:8000/v1.1/Things
# Before fix → {"value": []}  ✗
# After fix  → {"value": [{"name": "Station A", ...}]}  ✓
```
 
---
 
## Configuration
 
`REDIS_CACHE_TTL` (default: `300`) to control how long query plans are cached in seconds.

--- 
Fixes #143 