### PR TITLE
Set default DB statement logging to none

### DIFF
--- a/dev_docker-compose.yml
+++ b/dev_docker-compose.yml
@@ -18,7 +18,7 @@ services:
         -c custom.epsg=${EPSG:-4326}
         -c custom.user=${ISTSOS_ADMIN:-admin}
         -c custom.password=${ISTSOS_ADMIN_PASSWORD:-admin}
-        -c log_statement="all"
+        -c log_statement="none"
         -c log_destination="stderr"
         -c log_duration="on"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         -c custom.epsg=${EPSG:-4326}
         -c custom.user=${ISTSOS_ADMIN:-admin}
         -c custom.password=${ISTSOS_ADMIN_PASSWORD:-admin}
-        -c log_statement="all"
+        -c log_statement="none"
         -c log_destination="stderr"
         -c log_duration="on"
     ports:

--- a/edu_docker-compose.yml
+++ b/edu_docker-compose.yml
@@ -16,7 +16,7 @@ services:
         -c custom.epsg=${EPSG:-4326}
         -c custom.user=${ISTSOS_ADMIN:-admin}
         -c custom.password=${ISTSOS_ADMIN_PASSWORD:-admin}
-        -c log_statement="all"
+        -c log_statement="none"
         -c log_destination="stderr"
         -c log_duration="on"
     ports:


### PR DESCRIPTION

### Problem
Default SQL logging policy captures excessive statement detail and can leak sensitive operational data.

Previously, database containers were configured with `log_statement="all"`, causing every SQL statement to be logged and exposing sensitive values and internal query structure in logs. 

_The setting is explicitly hardcoded into startup command arguments and is active unless users edit compose files._

### Changes

This PR changes the default to `log_statement="none"` in all compose variants.


### Evidence
- `docker-compose.yml` sets `-c log_statement="all"`.
- `dev_docker-compose.yml` sets `-c log_statement="all"`.
- `edu_docker-compose.yml` sets `-c log_statement="all"`.