### PR TITLE
Fix SQL injection in get_foi_id by using parameterized query

### DIFF
--- a/api/app/v1/endpoints/create/bulk_observation.py
+++ b/api/app/v1/endpoints/create/bulk_observation.py
@@ -394,7 +394,7 @@ async def get_foi_id(datastream_id, conn, commit_id=None):
     """
 
     async with conn.transaction():
-        query_location_from_thing_datastream = f"""
+        query_location_from_thing_datastream = """
             SELECT
                 l.id,
                 l.name,
@@ -412,10 +412,10 @@ async def get_foi_id(datastream_id, conn, commit_id=None):
             JOIN
                 sensorthings."Location" l ON l.ID = tl.location_id
             WHERE
-                d.id = {datastream_id}
+                d.id = $1
         """
 
-        result = await conn.fetch(query_location_from_thing_datastream)
+        result = await conn.fetch(query_location_from_thing_datastream, datastream_id)
 
         if result:
             (


### PR DESCRIPTION
### Fix SQL injection in `get_foi_id`

This PR replaces string interpolation with a parameterized query in `get_foi_id`.

The previous implementation directly interpolated `datastream_id` into the SQL query, which could lead to SQL injection risks. This change uses asyncpg placeholders (`$1`) to ensure safe query execution.

This improves security and aligns with best practices used elsewhere in the codebase.