### PR TITLE
Fix incorrect Thing association format in HistoricalLocation endpoint

### DIFF
--- a/api/app/v1/endpoints/create/historical_location.py
+++ b/api/app/v1/endpoints/create/historical_location.py
@@ -133,7 +133,7 @@ async def create_historical_location_for_thing(
         if not thing_id:
             raise Exception("Thing ID is required.")
 
-        payload["Thing"] = {"@id": f"Things({thing_id})"}
+        payload["Thing"] = {"@iot.id": thing_id}
 
         validate_payload_keys(payload, ALLOWED_KEYS)
 


### PR DESCRIPTION
### Fix incorrect Thing association format in HistoricalLocation endpoint

**Problem:**
The `/Things({thing_id})/HistoricalLocations` endpoint was using `@id` for associations, which is inconsistent with the rest of the codebase.

**Fix:**
Replaced `@id` with `@iot.id` to match existing patterns and validation expectations.

**Evidence:**
Confirmed this was the only instance in the repository.
Validation utilities expect `@iot.id` and may fail when `@id` is used.