### PR TITLE
fix: correct parameter order in Thing_Location update query

### DIFF
--- a/api/app/v1/endpoints/update/functions.py
+++ b/api/app/v1/endpoints/update/functions.py
@@ -122,8 +122,8 @@ async def update_location_entity(
                     SET thing_id = $1
                     WHERE location_id = $2;
                 """,
-                location_id,
                 thing_id,
+                location_id,
             )
             if check is None:
                 await connection.execute(


### PR DESCRIPTION


Fixes #154 

In `update_location_entity` (`api/app/v1/endpoints/update/functions.py`, lines 119–127), the SQL bind parameters were passed in **reverse order**, causing silent data corruption on every `Location` update that modifies associated `Things`.

### Change

```diff
  await connection.fetchval(
      """
          UPDATE sensorthings."Thing_Location"
          SET thing_id = $1
          WHERE location_id = $2;
      """,
-     location_id,
-     thing_id,
+     thing_id,
+     location_id,
  )
```

### Impact

- **Before:** `$1` received `location_id` and `$2` received `thing_id` -wrong row targeted, wrong value written, no error raised
- **After:** Parameters match the SQL placeholders -correct row updated with the correct value
