### PR TITLE
fix: use RETURNING uri to prevent Commit.author NOT NULL violation

### DIFF
--- a/api/app/v1/endpoints/create/user.py
+++ b/api/app/v1/endpoints/create/user.py
@@ -126,11 +126,13 @@ async def create_user(
                     query = """
                         UPDATE sensorthings."User"
                         SET uri = $1 || $2 || $3 ||  '/Users(' || sensorthings."User".id || ')'
-                        WHERE sensorthings."User".id = $4;
+                        WHERE sensorthings."User".id = $4
+                        RETURNING uri;
                     """
-                    await connection.execute(
+                    generated_uri = await connection.fetchval(
                         query, HOSTNAME, SUBPATH, VERSION, user["id"]
                     )
+                    user = {**user, "uri": generated_uri}
 
                 if payload["role"] == "sensor":
                     commit = {


### PR DESCRIPTION
Fixes #156 

When creating a sensor user without an explicit `uri`, the code generates one via UPDATE but uses the stale in-memory value (`None`) as the commit author, violating the `NOT NULL` constraint on `Commit.author`.

### Change

```diff
  UPDATE sensorthings."User"
  SET uri = $1 || $2 || $3 || '/Users(' || sensorthings."User".id || ')'
- WHERE sensorthings."User".id = $4;
+ WHERE sensorthings."User".id = $4
+ RETURNING uri;

- await connection.execute(
+ generated_uri = await connection.fetchval(
      query, HOSTNAME, SUBPATH, VERSION, user["id"]
  )
+ user = {**user, "uri": generated_uri}
```

### Impact

- **Before:** Sensor user creation without `uri` crashes with `NOT NULL violation` on `Commit.author`
- **After:** The generated URI is captured via `RETURNING` and used as the commit author
