### PR TITLE
fix: missing comma syntax error in `data_array_observation.py` blocking test collection

### DIFF
--- a/api/app/v1/endpoints/create/data_array_observation.py
+++ b/api/app/v1/endpoints/create/data_array_observation.py
@@ -29,7 +29,7 @@ from app.utils.utils import (
     check_missing_properties,
     handle_datetime_fields,
     handle_result_field,
-    build_self_link
+    build_self_link,
     extract_iot_id
 )
 from app.v1.endpoints.functions import set_role

--- a/api/app/v1/endpoints/create/data_array_observation.py
+++ b/api/app/v1/endpoints/create/data_array_observation.py
@@ -30,7 +30,7 @@ from app.utils.utils import (
     handle_datetime_fields,
     handle_result_field,
     build_self_link,
-    extract_iot_id
+    extract_iot_id,
 )
 from app.v1.endpoints.functions import set_role
 from asyncpg.exceptions import InsufficientPrivilegeError


### PR DESCRIPTION
## Summary 

Fixes a syntax error in `data_array_observation.py` caused by a previous import line missing a trailing comma. When a later PR added another import entry on a different branch, the combined changes unintentionally produced invalid syntax.

This blocked module imports and caused all tests to fail during `pytest` collection.

Small, targeted fix with no logic changes.
