### PR TITLE
fix: correct error handling in read endpoints to return proper HTTP s…

### DIFF
--- a/api/app/v1/endpoints/read/commit.py
+++ b/api/app/v1/endpoints/read/commit.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -97,13 +101,36 @@ async def get_commits(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_commits")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_commits")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/datastream.py
+++ b/api/app/v1/endpoints/read/datastream.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_datastreams(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_datastreams")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_datastreams")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/feature_of_interest.py
+++ b/api/app/v1/endpoints/read/feature_of_interest.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_features_of_interest(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_features_of_interest")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_features_of_interest")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/historical_location.py
+++ b/api/app/v1/endpoints/read/historical_location.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_historical_locations(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_historical_locations")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_historical_locations")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/location.py
+++ b/api/app/v1/endpoints/read/location.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_locations(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_locations")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_locations")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/network.py
+++ b/api/app/v1/endpoints/read/network.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_networks(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_networks")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_networks")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/observation.py
+++ b/api/app/v1/endpoints/read/observation.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_observations(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_observations")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_observations")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/observed_property.py
+++ b/api/app/v1/endpoints/read/observed_property.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_observed_properties(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_observed_properties")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_observed_properties")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/sensor.py
+++ b/api/app/v1/endpoints/read/sensor.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_sensors(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_sensors")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_sensors")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:

--- a/api/app/v1/endpoints/read/thing.py
+++ b/api/app/v1/endpoints/read/thing.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 
+import asyncpg
 from app import ANONYMOUS_VIEWER, AUTHORIZATION, REDIS
 from app.db.asyncpg_db import get_pool
 from app.db.redis_db import redis
@@ -23,6 +25,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .query_parameters import CommonQueryParams, get_common_query_params
 from .read import asyncpg_stream_results, wrapped_result_generator
+
+logger = logging.getLogger(__name__)
 
 v1 = APIRouter()
 
@@ -96,13 +100,36 @@ async def get_things(
                 media_type="application/json",
                 status_code=status.HTTP_200_OK,
             )
-        except Exception as e:
+        except StopAsyncIteration:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={
                     "code": 404,
                     "type": "error",
                     "message": "Not Found",
+                },
+            )
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.TooManyConnectionsError,
+        ):
+            logger.exception("Database unavailable in get_things")
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": 503,
+                    "type": "error",
+                    "message": "Database temporarily unavailable",
+                },
+            )
+        except Exception:
+            logger.exception("Unexpected streaming error in get_things")
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "code": 500,
+                    "type": "error",
+                    "message": "Internal server error",
                 },
             )
     except Exception as e:


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in all read endpoints where a broad exception handler was incorrectly mapping all runtime failures to HTTP 404 Not Found, including database connection errors and internal server errors. This made it impossible for clients to distinguish between legitimate "not found" scenarios and actual backend failures.

## Problem

All read endpoints in `api/app/v1/endpoints/read/` had the following problematic pattern:

```python
try:
    first_item = await anext(result)
    return StreamingResponse(...)
except Exception as e:
    return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, ...)
```

This caused several issues:
- Database connection failures returned 404 instead of 503
- Internal errors returned 404 instead of 500
- No error logging, making debugging impossible
- Clients couldn't implement proper retry logic
- Production issues were masked as "not found" errors

## Solution

Implemented specific exception handling to return appropriate HTTP status codes:

- **404 Not Found**: Only when query returns no results (StopAsyncIteration)
- **503 Service Unavailable**: For database connection issues
- **500 Internal Server Error**: For unexpected errors

Added proper logging for all exceptions to improve observability.

```python
try:
    first_item = await anext(result)
    return StreamingResponse(...)
except StopAsyncIteration:
    return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, ...)
except (asyncpg.PostgresConnectionError, asyncpg.TooManyConnectionsError):
    logger.exception("Database unavailable")
    return JSONResponse(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, ...)
except Exception:
    logger.exception("Unexpected streaming error")
    return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, ...)
```

## Changes

### Modified Files (10)
- `api/app/v1/endpoints/read/sensor.py`
- `api/app/v1/endpoints/read/thing.py`
- `api/app/v1/endpoints/read/datastream.py`
- `api/app/v1/endpoints/read/observation.py`
- `api/app/v1/endpoints/read/historical_location.py`
- `api/app/v1/endpoints/read/feature_of_interest.py`
- `api/app/v1/endpoints/read/location.py`
- `api/app/v1/endpoints/read/observed_property.py`
- `api/app/v1/endpoints/read/network.py`
- `api/app/v1/endpoints/read/commit.py`

### Key Changes Per File
- Added `import logging` and `import asyncpg`
- Added `logger = logging.getLogger(__name__)`
- Replaced broad `except Exception` with specific exception handlers
- Added `StopAsyncIteration` handler for legitimate 404 cases
- Added database exception handlers for 503 cases
- Added generic exception handler with logging for 500 cases


## Impact

### Before
| Scenario | Response |
|----------|----------|
| No results | 404 |
| DB connection lost | 404 (wrong) |
| Internal error | 404 (wrong) |
| No logging | N/A |

### After
| Scenario | Response |
|----------|----------|
| No results | 404 |
| DB connection lost | 503 (correct) |
| Internal error | 500 (correct) |
| All errors logged | Yes |

## Benefits

1. **Correct HTTP semantics**: Proper status codes enable appropriate client behavior
2. **Better observability**: All errors are now logged with full stack traces
3. **Improved debugging**: Developers can identify database vs application issues
4. **Better user experience**: Clients can implement proper retry logic based on status codes

## Breaking Changes

None. This only affects error responses, and the change makes them more correct according to HTTP standards.

Closes #161 
