### PR TITLE
fix: replace blocking Redis client with async implementation

### DIFF
--- a/api/app/db/redis_db.py
+++ b/api/app/db/redis_db.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import redis
+import redis.asyncio as aioredis
 
-redis = redis.Redis(host="redis")
+redis = aioredis.Redis(host="redis")
 
 
-def remove_cache(path):
+async def remove_cache(path):
     """
     Remove the cache for the specified path.
 
@@ -29,13 +29,12 @@ def remove_cache(path):
     """
     # Pattern da cercare nelle chiavi (ad esempio 'testop')
     pattern = "*{}*".format(path)
-
     # Itera su tutte le chiavi che corrispondono al pattern
+
     cursor = 0
     while True:
-        cursor, keys = redis.scan(cursor=cursor, match=pattern)
+        cursor, keys = await redis.scan(cursor=cursor, match=pattern)
         if keys:
-            # Cancella le chiavi trovate
-            redis.delete(*keys)
+            await redis.delete(*keys)
         if cursor == 0:
             break

--- a/api/app/v1/endpoints/create/login.py
+++ b/api/app/v1/endpoints/create/login.py
@@ -38,7 +38,7 @@ def _extract_bearer_token(authorization: str | None) -> str:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid authorization header format",
         )
-    return authorization[len(prefix) :].strip()
+    return authorization[len(prefix):].strip()
 
 
 def _ttl_from_exp(exp: int | float | str | None) -> int:
@@ -89,14 +89,7 @@ async def login(
 async def refresh_token(authorization: str | None = Header(default=None)):
     token = _extract_bearer_token(authorization)
 
-    if REDIS and redis.get(token) is not None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token has been revoked",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    if REDIS and redis.get(token) is not None:
+    if REDIS and await redis.get(token) is not None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token has been revoked",
@@ -113,7 +106,7 @@ async def refresh_token(authorization: str | None = Header(default=None)):
 
     if REDIS:
         expire = payload.get("exp")
-        redis.set(token, "refreshed", ex=_ttl_from_exp(expire))
+        await redis.set(token, "refreshed", ex=_ttl_from_exp(expire))
 
     access_token, expire = create_refresh_token(payload)
 
@@ -147,7 +140,7 @@ async def logout(authorization: str | None = Header(default=None)):
 
     if REDIS:
         expire = payload.get("exp")
-        redis.set(token, "logged_out", ex=_ttl_from_exp(expire))
+        await redis.set(token, "logged_out", ex=_ttl_from_exp(expire))
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,


### PR DESCRIPTION
### Use async Redis client for non-blocking operations

**Problem**
The synchronous `redis.Redis` client was blocking the asyncio event loop on every token check and cache update, stalling concurrent requests.

**Changes**
- `redis_db.py`: switched to `redis.asyncio.Redis` and made `remove_cache` async
- `login.py`: added `await` to all Redis calls

**Bonus fix**
-  fixed duplicate revocation check in `/Refresh` (was checking the same condition twice)

**Notes**
- Existing behavior is preserved (TTL handling and token revocation logic unchanged)
- Import name `redis` is kept to avoid a larger diff across the codebase