### PR TITLE
fix(auth): deduplicate users in add_users_to_policy

### DIFF
--- a/database/istsos_auth.sql
+++ b/database/istsos_auth.sql
@@ -775,7 +775,7 @@ FOR tablename IN SELECT unnest(tables)
                 RAISE EXCEPTION USING ERRCODE = '42704';
             END IF;
             
-            new_roles_ := old_roles_ || users_;
+            new_roles_ := (SELECT array_agg(DISTINCT x) FROM unnest(old_roles_ || users_) AS x);
             
             EXECUTE format('ALTER POLICY %I ON sensorthings.%I TO %s', policyname_, tablename_, array_to_string(new_roles_, ','));
 

--- a/test/database/test_auth_sql.py
+++ b/test/database/test_auth_sql.py
@@ -676,6 +676,54 @@ class TestAuth:
                     (["guest"], "nonexistent_policy_xyz"),
                 )
 
+    def test_add_users_to_policy_deduplicates_duplicate_users(self, schema):
+        """
+        add_users_to_policy must remove duplicate usernames when the same user
+        is added multiple times (either across calls or within the same call).
+        """
+        pname = "test-dedup-pol"
+        with schema.cursor() as cur:
+            # Create initial policy with alice, bob
+            cur.execute(
+                "SELECT sensorthings.viewer_policy(%s::text[], %s)",
+                (["alice", "bob"], pname),
+            )
+
+            # Verify initial state: each policy should have exactly alice, bob
+            cur.execute(
+                """
+                SELECT roles FROM pg_policies
+                WHERE schemaname = 'sensorthings'
+                  AND policyname LIKE %s
+                ORDER BY tablename
+                """,
+                (f"{pname}%",),
+            )
+            initial_roles = [row[0] for row in cur.fetchall()]
+            assert all(set(r) == {"alice", "bob"} for r in initial_roles)
+
+            # Add duplicates: alice and bob already present, add bob again + charlie
+            cur.execute(
+                "SELECT sensorthings.add_users_to_policy(%s::text[], %s)",
+                (["alice", "bob", "charlie"], pname),
+            )
+
+            # Verify deduplication: final set should be {alice, bob, charlie}
+            cur.execute(
+                """
+                SELECT roles FROM pg_policies
+                WHERE schemaname = 'sensorthings'
+                  AND policyname LIKE %s
+                ORDER BY tablename
+                """,
+                (f"{pname}%",),
+            )
+            final_roles = [row[0] for row in cur.fetchall()]
+            for roles in final_roles:
+                assert sorted(roles) == ["alice", "bob", "charlie"], (
+                    f"Expected deduped ['alice','bob','charlie'], got {roles}"
+                )
+
     # ------------------------------------------------------------------
     # 10. Btree indexes on commit_id
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Description

The add_users_to_policy function in database/istsos_auth.sql used simple array concatenation (old_roles_ || users_), which allows duplicate usernames to accumulate across repeated calls. Over time this causes role array drift, making audits harder and potentially leading to unexpected behavior.

Root cause Line 778 previously read:

``` new_roles_ := old_roles_ || users_; ``` 

This merges arrays without removing duplicates.

Fix Changed the merge to deduplicate using DISTINCT:

 ``` new_roles_ := (SELECT array_agg(DISTINCT x) FROM unnest(old_roles_ || users_) AS x); ```

This ensures the resulting array always contains unique usernames, whether duplicates existed in old_roles_, appear in users_, or span across both arrays.

## Changes

- ``` database/istsos_auth.sql ```  - fixed the array merge 
- ``` test/database/test_auth_sql.py  ``` - added regression test test_add_users_to_policy_deduplicates_duplicate_users

Migration Existing databases may already have duplicate entries in policy role arrays. After deploying this fix, run a one-time cleanup:

``` UPDATE pg_policies SET roles = (SELECT array_agg(DISTINCT r) FROM unnest(roles) AS r) WHERE schemaname = 'sensorthings'; ```

Alternatively, recreate policies via the existing admin endpoints.

## Testing The new regression test verifies:

- Policy creation with initial users
- Adding a mix of already-present and new users
- Final role arrays contain exactly the deduplicated set

Run: pytest test/database/test_auth_sql.py::TestAuth::test_add_users_to_policy_deduplicates_duplicate_users