### PR TITLE
Fix crash when 'resultTime' is missing in components

### DIFF
--- a/api/app/v1/endpoints/create/bulk_observation.py
+++ b/api/app/v1/endpoints/create/bulk_observation.py
@@ -210,7 +210,7 @@ async def insertBulkObservation(
         if components:
             result_idx = components.index("result")
             ph_idx = components.index("phenomenonTime")
-            if components.index("resultTime") > -1:
+            if "resultTime" in components:
                 result_time_idx = components.index("resultTime")
             if isinstance(payload[0][result_idx], str):
                 result_type = 3


### PR DESCRIPTION
Fixes a crash in `insertBulkObservation` when `resultTime` is not present in `components`.

The previous implementation called `components.index("resultTime")` without checking for its existence first. 
`list.index()` raises a `ValueError` if the item is not found (it does not return `-1`). 
Fixed by replacing with `if "resultTime" in components` before calling `.index()`.
