### PR TITLE
Remove redundant try/except DEBUG block in sta2rest.py

### DIFF
--- a/api/app/sta2rest/sta2rest.py
+++ b/api/app/sta2rest/sta2rest.py
@@ -33,11 +33,6 @@ from .sta_parser.lexer import Lexer
 from .sta_parser.parser import Parser
 from .visitors import NodeVisitor
 
-try:
-    DEBUG = DEBUG
-except:
-    DEBUG = 0
-
 
 class STA2REST:
     """


### PR DESCRIPTION
**Problem**
`DEBUG` is already imported from `app` on the line above the block:

```python
from app import AUTHORIZATION, DEBUG, NETWORK, VERSION, VERSIONING

try:
    DEBUG = DEBUG  # does nothing
except:
    DEBUG = 0      # never reached
```

`DEBUG` is always defined at this point — the `try/except` can never raise, making the entire block dead code.

**Change**
- `sta2rest.py`: removed the 4-line `try/except DEBUG` block

**Notes**
- No behavior change