### PR TITLE
fix(tests): add `qc` to ALL_SCHEMA_ROLES in conftest to prevent DuplicateObject on re-runs

### DIFF
--- a/test/database/conftest.py
+++ b/test/database/conftest.py
@@ -92,7 +92,7 @@ VERSIONING_SQL = DATABASE_DIR / "istsos_schema_versioning.sql"
 
 # All roles that any of the three SQL layers can create.
 # Used as the default set to clean up during recreate_database.
-ALL_SCHEMA_ROLES = ("administrator", "testuser", "user", "guest", "sensor")
+ALL_SCHEMA_ROLES = ("administrator", "testuser", "user", "guest", "sensor", "qc")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
All `TestAuth` tests were erroring at setup with `psycopg2.errors.DuplicateObject: role "qc" already exists`. 

Tracing the failure back, the `qc` role was introduced in the auth SQL to support Quality Control workflows (SELECT/UPDATE on Observation, INSERT on Commit), but `ALL_SCHEMA_ROLES` in conftest was never updated to include it. This meant `recreate_database` never cleaned up `qc` between runs, and the second run would crash when `istsos_auth.sql` tried to `CREATE ROLE "qc"` again.

Fix is a one-liner: add `"qc"` to `ALL_SCHEMA_ROLES` so the cleanup loop in `recreate_database` drops and re-creates it along with the other roles on every test run.

The commit in context is 03d3235
