### PR TITLE
fix(mapping): restore singular key for `FeatureOfInterest` in ENTITY_URL_NAMES

### DIFF
--- a/api/app/utils/utils.py
+++ b/api/app/utils/utils.py
@@ -30,7 +30,7 @@ ENTITY_URL_NAMES = {
     "Datastream": "Datastreams",
     "Observation": "Observations",
     "ObservedProperty": "ObservedProperties",
-    "FeaturesOfInterest": "FeaturesOfInterest",
+    "FeatureOfInterest": "FeaturesOfInterest",
     "HistoricalLocation": "HistoricalLocations",
     "Network": "Networks",
 }


### PR DESCRIPTION
This PR restores the singular key `"FeatureOfInterest"` in the `ENTITY_URL_NAMES` mapping table. During recent testing of the geometry insertion logic, I encountered a ValueError in build_self_link that was causing the test_feature_key_uses_st_geomfromgeojson test to fail. After debugging the regression, I traced the root cause back to commit 423aba9, where this key was likely updated to its plural form by mistake.

I initially questioned if my test logic was incorrect, but after observing that other geometry insertion tests for entities like Location continue to pass using singular keys, I verified the requirement against the `OGC SensorThings API` standards. The specification confirms that while the `URL` path is `plural` (FeaturesOfInterest), the formal `Entity Name` used for creation and internal mapping should remain `singular` (FeatureOfInterest). This character fix restores consistency across the mapping table and ensures all unit tests pass as expected.

## Related Changes
Reverts the mapping change from commit 423aba9.
