### PR TITLE
fix: $resultFormat=CSV and GeoJSON crash server with 500, parser token missing

### DIFF
--- a/api/app/sta2rest/sta_parser/lexer.py
+++ b/api/app/sta2rest/sta_parser/lexer.py
@@ -33,7 +33,7 @@ TOKEN_TYPES = {
     "ASOF": r"\$as_of=",
     "FROMTO": r"\$from_to=",
     "RESULT_FORMAT": r"\$resultFormat=",
-    "RESULT_FORMAT_VALUE": r"\bdataArray\b",
+    "RESULT_FORMAT_VALUE": r"\bdataArray\b|\bCSV\b|\bGeoJSON\b",
     "SUBQUERY_SEPARATOR": r";",
     "VALUE_SEPARATOR": r",",
     "OPTIONS_SEPARATOR": r"&",

--- a/api/app/v1/endpoints/read/read.py
+++ b/api/app/v1/endpoints/read/read.py
@@ -101,7 +101,6 @@ async def catch_all_get(
     pool=Depends(get_pool),
     params: CommonQueryParams = Depends(get_common_query_params),
 ):
-
     if not path_name:
         return __handle_root()
 
@@ -121,7 +120,17 @@ async def catch_all_get(
                 print("Cache miss")
 
         if not data:
-            data = sta2rest.STA2REST.convert_query(full_path)
+            try:
+                data = sta2rest.STA2REST.convert_query(full_path)
+            except Exception as e:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={
+                        "code": 400,
+                        "type": "error",
+                        "message": f"Invalid query: {str(e)}",
+                    },
+                )
 
         main_entity = data.get("main_entity")
         main_query = data.get("main_query")


### PR DESCRIPTION
While working on the STA to STAC metadata connector, I needed to fetch observations in CSV format to test the pipeline. Every request with `$resultFormat=CSV` was returning 500, so I pulled the Docker logs and traced the error.

The root cause was in `lexer.py` where the `RESULT_FORMAT_VALUE` token pattern only matched `dataArray`. So when the parser saw `CSV`, it tokenized it as an `EXPAND_IDENTIFIER` and threw an exception. That exception had no dedicated handler in `read.py`, so it fell through to the generic `except Exception` block and returned 500.

**Changes**

`lexer.py` => extend the pattern to cover all three spec-defined values:
```
# before
"RESULT_FORMAT_VALUE": r"\bdataArray\b",
# after
"RESULT_FORMAT_VALUE": r"\bdataArray\b|\bCSV\b|\bGeoJSON\b",
```

`read.py` => wrap `convert_query` in its own try/except returning 400. Parser exceptions are always caused by malformed client input, not server faults, so 500 was the wrong code here regardless.

**Note**

While tracing this I found that CSV and GeoJSON serialization is not actually implemented. The parser scaffolding exists, `ResultFormatNode`, `parse_result_format`, and the entity validation in `convert_query` are all there, but `result_format` is never passed through to the return dict or the streaming layer in `read.py`, so the response is always JSON regardless of what `$resultFormat` is set to. Only `dataArray` appears to have any downstream handling.

This PR only fixes the 500 and the wrong error code. The actual serialization is a separate feature that needs to be built. I am opening a separate issue for that.

**References**

OGC SensorThings API Part 1, Section 9.3.4 => valid `$resultFormat` values are `dataArray`, `CSV`, and `GeoJSON`.

<img width="921" height="479" alt="Screenshot 2026-05-29 151333" src="https://github.com/user-attachments/assets/c72f3e4e-bb7c-4aab-986d-b113dc425f44" />
<img width="996" height="760" alt="Screenshot 2026-05-29 151232" src="https://github.com/user-attachments/assets/37618536-2304-49a4-bbf6-28c7f62d1846" />
